### PR TITLE
feat: add .claude-plugin manifests with userConfig for vault path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "name": "claude-obsidian",
+  "owner": {
+    "name": "Michał Konopski",
+    "email": "michal.konopski@camunda.com"
+  },
+  "metadata": {
+    "description": "claude-obsidian: Claude + Obsidian knowledge companion by Michał Konopski"
+  },
+  "plugins": [
+    {
+      "name": "claude-obsidian",
+      "source": "./",
+      "description": "Claude + Obsidian knowledge companion. Sets up a persistent, compounding wiki vault.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Michał Konopski",
+        "url": "https://github.com/misiekhardcore"
+      },
+      "homepage": "https://github.com/misiekhardcore/claude-obsidian",
+      "repository": "https://github.com/misiekhardcore/claude-obsidian",
+      "license": "MIT"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "claude-obsidian",
   "owner": {
     "name": "Michał Konopski",
-    "email": "michal.konopski@camunda.com"
+    "email": "misiekhardcore@gmail.com"
   },
   "metadata": {
     "description": "claude-obsidian: Claude + Obsidian knowledge companion by Michał Konopski"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "claude-obsidian",
-  "version": "1.0.0",
   "description": "Claude + Obsidian knowledge companion. Sets up a persistent, compounding wiki vault. Covers memory management, session notetaking, knowledge organization, and agent context across projects.",
   "author": {
     "name": "Michał Konopski",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,45 @@
+{
+  "name": "claude-obsidian",
+  "version": "1.0.0",
+  "description": "Claude + Obsidian knowledge companion. Sets up a persistent, compounding wiki vault. Covers memory management, session notetaking, knowledge organization, and agent context across projects.",
+  "author": {
+    "name": "Michał Konopski",
+    "url": "https://github.com/misiekhardcore"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/misiekhardcore/claude-obsidian",
+  "repository": "https://github.com/misiekhardcore/claude-obsidian",
+  "keywords": [
+    "obsidian",
+    "knowledge-base",
+    "wiki",
+    "memory",
+    "notetaker",
+    "second-brain",
+    "vault",
+    "markdown",
+    "cross-project",
+    "llm-wiki",
+    "karpathy",
+    "pkm",
+    "canvas",
+    "visual"
+  ],
+  "userConfig": {
+    "vault_path": {
+      "description": "Absolute path to your Obsidian vault"
+    }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"${user_config.vault_path}\" ] && echo \"claude-obsidian: vault=${user_config.vault_path}\" || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -28,17 +28,5 @@
     "vault_path": {
       "description": "Absolute path to your Obsidian vault"
     }
-  },
-  "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "[ -n \"${user_config.vault_path}\" ] && echo \"claude-obsidian: vault=${user_config.vault_path}\" || true"
-          }
-        ]
-      }
-    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude/NOTES.md


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/plugin.json` with full metadata (name, description, author, license, homepage, repository, keywords) and `userConfig.vault_path` so Claude Code prompts the user for their Obsidian vault path at plugin-enable time
- Adds `.claude-plugin/marketplace.json` using the self-describing single-repo pattern (`source: "./"`) enabling `claude plugin marketplace add misiekhardcore/claude-obsidian` → `claude plugin install claude-obsidian@claude-obsidian`
- Includes a `SessionStart` hook in `plugin.json` that echoes `${user_config.vault_path}` to confirm the userConfig substitution mechanism works (will be superseded by the production hooks in issue #5)

Closes #3

## Manual testing

1. Clone this branch locally
2. Run `claude plugin validate .` from the repo root — should print `✔ Validation passed`
3. Run `claude plugin marketplace add ./` from the repo root — should register the `claude-obsidian` marketplace
4. Run `claude plugin install claude-obsidian@claude-obsidian` — should prompt for vault path and install
5. Start a new Claude Code session — `SessionStart` hook should echo `claude-obsidian: vault=<your-path>`

> Note: steps 3–5 require the branch to be accessible (local path works for steps 3–5; GitHub install works after merge to main).