### PR TITLE
feat: rewrite hooks.json + add resolve-vault.sh

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,56 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
+          },
+          {
+            "type": "prompt",
+            "prompt": "If a vault is configured for this session (check CLAUDE.md for VAULT_PATH or a wiki/ folder in the current directory), silently read wiki/hot.md to restore recent context. If wiki/hot.md does not exist, do nothing. This is a non-vault session. Do not announce this. Do not report what you read. Just have the context available."
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
+          },
+          {
+            "type": "prompt",
+            "prompt": "Hook-injected context does not survive context compaction. If wiki/hot.md exists in the vault, silently re-read it now to restore the hot cache. Do not announce this."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; [ -d \"$VAULT/.git\" ] && git -C \"$VAULT\" add wiki/ .raw/ 2>/dev/null && (git -C \"$VAULT\" diff --cached --quiet || git -C \"$VAULT\" commit -m \"wiki: auto-commit $(date '+%Y-%m-%d %H:%M')\" 2>/dev/null) || true"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; [ -d \"$VAULT/wiki\" ] && [ -d \"$VAULT/.git\" ] && git -C \"$VAULT\" diff --name-only HEAD 2>/dev/null | grep -q '^wiki/' && echo 'WIKI_CHANGED: Wiki pages were modified this session. Please update $VAULT/wiki/hot.md with a brief summary of what changed (under 500 words). Use the hot cache format: Last Updated, Key Recent Facts, Recent Changes, Active Threads. Keep it factual. Overwrite the file completely. It is a cache, not a journal.' || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/resolve-vault.sh
+++ b/scripts/resolve-vault.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+VAULT="${user_config.vault_path}"
+[ -z "$VAULT" ] && [ -d "$(pwd)/wiki" ] && VAULT="$(pwd)"
+if [ -z "$VAULT" ]; then
+  echo "claude-obsidian: no vault configured — run /wiki init to set up" >&2
+  exit 1
+fi
+echo "$VAULT"


### PR DESCRIPTION
## Summary

- Create `scripts/resolve-vault.sh`: New executable that resolves vault path from `${user_config.vault_path}` or falls back to cwd if `wiki/` folder exists
- Rewrite `hooks/hooks.json`: All 4 hooks (SessionStart, PostCompact, PostToolUse, Stop) now call resolve-vault.sh before operating on vault paths
- Eliminate all hardcoded relative `wiki/` paths; use `$VAULT/wiki/` and `git -C "$VAULT"` throughout

## Changes by Hook

- **SessionStart**: Read `$VAULT/wiki/hot.md` for context restoration on startup/resume
- **PostCompact**: Re-read `$VAULT/wiki/hot.md` after context compaction
- **PostToolUse**: Auto-commit `wiki/` and `.raw/` via `git -C "$VAULT"` on Write/Edit
- **Stop**: Detect wiki changes and prompt to update `$VAULT/wiki/hot.md`

## Manual Testing

\`\`\`bash
# Verify script is executable
ls -l scripts/resolve-vault.sh | grep -q 'x' && echo "✓ executable"

# Verify shell syntax
bash -n scripts/resolve-vault.sh && echo "✓ syntax OK"

# Verify JSON validity
jq . hooks/hooks.json >/dev/null && echo "✓ JSON valid"

# Verify no hardcoded wiki/ paths in command fields
jq '.hooks | to_entries[] | .value[] | select(.hooks) | .hooks[] | select(.type == "command") | .command' hooks/hooks.json | grep -v '\$VAULT' | wc -l
# Expected: 0 (all paths use $VAULT/wiki/)
\`\`\`

## Closes #5