### PR TITLE
docs: add vault assumptions section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 Guidance for using claude-obsidian as a Claude Code plugin.
 
+## Vault Assumptions
+
+This vault is designed for **agent-only** use with **single-user, single-machine** access patterns. Any feature proposal violating one of these assumptions must be challenged before implementation:
+
+- **Agent-only readers/writers.** No multi-user tiering, reviewer workflow, access control, or `reviewed_at` timestamps. Every write is an agent or the single human owner; human review happens via git, not via in-vault metadata.
+- **Single-user, single-machine by default.** Cross-project access is opt-in per-project, not a multi-tenant design target.
+- **Git-backed, file-per-page.** No database, no server, no live sync. All coordination is via commit history.
+
 ## Plugin Setup
 
 This is both a Claude Code plugin and an Obsidian vault. To use it:


### PR DESCRIPTION
## Summary

Adds a new "Vault Assumptions" section to CLAUDE.md near the top, right after the intro block and before "Plugin Setup". This section documents the three core constraints for the vault design:
- Agent-only readers/writers (no multi-user/reviewer metadata)
- Single-user, single-machine by default (opt-in cross-project access)
- Git-backed, file-per-page (no database/server/live sync)

Includes a lead-in statement that any feature violating these assumptions must be challenged before implementation.

Closes #16

This PR stacks on #13 (feat/8-docs) and should be merged after #13.