### PR TITLE
feat(wiki): wire /wiki init to setup-vault.sh

### DIFF
--- a/commands/wiki.md
+++ b/commands/wiki.md
@@ -1,8 +1,45 @@
 ---
-description: Bootstrap or check the claude-obsidian wiki vault. Reads the wiki skill and runs setup workflow.
+description: Bootstrap or check the claude-obsidian wiki vault. Use `/wiki init` to seed the vault from the configured path; `/wiki` (no args) runs the scaffold workflow.
+argument-hint: "[init]"
 ---
 
-Read the `wiki` skill. Then run the setup workflow:
+Read the `wiki` skill.
+
+If the argument is `init`, run the **INIT** operation below. Otherwise, run the **SCAFFOLD** workflow described in the skill.
+
+## INIT
+
+1. Resolve the vault path from `${user_config.vault_path}`. If it is empty, print exactly this line and stop without error:
+
+   ```
+   Configure vault path first: enable the plugin and enter your vault path when prompted
+   ```
+
+2. Run the setup script:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/bin/setup-vault.sh" "${user_config.vault_path}"
+   ```
+
+3. Copy the plugin's `_templates/` into the vault, skipping existing files so the step is idempotent:
+
+   ```bash
+   mkdir -p "${user_config.vault_path}/_templates"
+   for src in "${CLAUDE_PLUGIN_ROOT}/_templates/"*.md; do
+     dst="${user_config.vault_path}/_templates/$(basename "$src")"
+     [ -e "$dst" ] || cp "$src" "$dst"
+   done
+   ```
+
+4. Print next steps:
+
+   - Open Obsidian → *Manage Vaults* → *Open folder as vault* and select `${user_config.vault_path}`.
+   - Enable community plugins when prompted, then install **Dataview**, **Templater**, and **Obsidian Git** from Settings → Community Plugins.
+   - Run `/wiki` to scaffold your knowledge base.
+
+Re-running `/wiki init` must be idempotent: `setup-vault.sh` already guards existing files, and `cp -n` skips templates that are already in the vault.
+
+## SCAFFOLD (default)
 
 1. Check if Obsidian is installed. If not, offer to install it (see `skills/wiki/references/plugins.md`).
 2. Check if this directory has a vault (look for `.obsidian/` folder). If yes, report current vault state.

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -101,6 +101,7 @@ Route to the correct operation based on what the user says:
 
 | User says | Operation | Sub-skill |
 |-----------|-----------|-----------|
+| "/wiki init", "init vault", "bootstrap vault" | INIT | this skill |
 | "scaffold", "set up vault", "create wiki" | SCAFFOLD | this skill |
 | "ingest [source]", "process this", "add this" | INGEST | `ingest` |
 | "what do you know about X", "query:" | QUERY | `query` |
@@ -108,6 +109,38 @@ Route to the correct operation based on what the user says:
 | "save this", "file this", "/save" | SAVE | `save` |
 | "/autoresearch [topic]", "research [topic]" | AUTORESEARCH | `autoresearch` |
 | "/canvas", "add to canvas", "open canvas" | CANVAS | `canvas` |
+
+---
+
+## INIT Operation
+
+Trigger: `/wiki init`, "init vault", "bootstrap vault".
+
+Goal: seed an empty vault from `${user_config.vault_path}` so the user can open it in Obsidian. This is a one-shot, idempotent bootstrap — it does not ask questions and does not scaffold the knowledge base (that is SCAFFOLD).
+
+Steps:
+
+1. Resolve `${user_config.vault_path}`. If empty, print:
+
+   `Configure vault path first: enable the plugin and enter your vault path when prompted`
+
+   Then stop without error.
+
+2. Run `bash "${CLAUDE_PLUGIN_ROOT}/bin/setup-vault.sh" "${user_config.vault_path}"` — creates `.obsidian/`, `.raw/`, `wiki/`, `_templates/` and the Obsidian config files.
+
+3. Copy templates from the plugin into the vault, skipping existing files:
+
+   ```bash
+   mkdir -p "${user_config.vault_path}/_templates"
+   for src in "${CLAUDE_PLUGIN_ROOT}/_templates/"*.md; do
+     dst="${user_config.vault_path}/_templates/$(basename "$src")"
+     [ -e "$dst" ] || cp "$src" "$dst"
+   done
+   ```
+
+4. Print next steps: open Obsidian at the vault path, enable community plugins (Dataview, Templater, Obsidian Git), then run `/wiki` to scaffold the knowledge base.
+
+Re-running is idempotent: `setup-vault.sh` guards existing files and the copy loop skips templates already present.
 
 ---
 


### PR DESCRIPTION
## Summary

- `/wiki init` now seeds a vault from `${user_config.vault_path}` via `${CLAUDE_PLUGIN_ROOT}/bin/setup-vault.sh`, copies plugin `_templates/` into the vault (skipping existing files), and prints next steps.
- If `vault_path` is empty, the command prints `Configure vault path first: enable the plugin and enter your vault path when prompted` and stops without error.
- Re-running is idempotent (setup-vault.sh guards existing files; template copy skips existing names).
- `/wiki` with no argument still runs the SCAFFOLD workflow.

Touches: `commands/wiki.md`, `skills/wiki/SKILL.md`.

Closes #7

## Test plan

- [x] Manually verified double-run against a scratch vault in `/tmp`: `setup-vault.sh` + template copy both run clean on first and second invocation; `diff -r _templates $VAULT/_templates` matches.
- [ ] End-to-end check: run `/wiki init` in Claude Code with `vault_path` set, confirm vault opens in Obsidian.
- [ ] End-to-end check: run `/wiki init` with `vault_path` unset, confirm the error message appears and nothing is written.