### PR TITLE
refactor(wiki): extract init logic into bin scripts

### DIFF
--- a/bin/copy-templates.sh
+++ b/bin/copy-templates.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Copy the plugin's _templates/*.md into $VAULT/_templates/, skipping any
+# files that already exist (idempotent).
+#
+# Usage: bin/copy-templates.sh /absolute/path/to/vault
+
+set -euo pipefail
+
+if [ -z "${1:-}" ]; then
+  echo "Error: vault path is required" >&2
+  echo "Usage: bin/copy-templates.sh /absolute/path/to/vault" >&2
+  exit 1
+fi
+
+VAULT="$1"
+
+# Locate the plugin root. Prefer CLAUDE_PLUGIN_ROOT when set (in-session).
+# Otherwise derive it from $0 so standalone invocations work.
+if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  SCRIPT_PATH=$(readlink -f "$0" 2>/dev/null || python3 -c "import os,sys;print(os.path.realpath(sys.argv[1]))" "$0")
+  CLAUDE_PLUGIN_ROOT=$(dirname "$(dirname "$SCRIPT_PATH")")
+  export CLAUDE_PLUGIN_ROOT
+fi
+
+SRC_DIR="${CLAUDE_PLUGIN_ROOT}/_templates"
+DST_DIR="${VAULT}/_templates"
+
+mkdir -p "$DST_DIR"
+
+for src in "$SRC_DIR"/*.md; do
+  [ -e "$src" ] || continue
+  dst="$DST_DIR/$(basename "$src")"
+  [ -e "$dst" ] || cp "$src" "$dst"
+done

--- a/bin/wiki-init.sh
+++ b/bin/wiki-init.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Umbrella script for `/wiki init`. Seeds an Obsidian vault from the path
+# passed in $1 by delegating to setup-vault.sh + copy-templates.sh, then
+# prints next steps. Re-running is idempotent.
+#
+# Usage: bin/wiki-init.sh /absolute/path/to/vault
+#
+# If $1 is empty, prints the configured "vault not set" message and exits 0
+# (no error) so `/wiki init` can guide the user to set vault_path without
+# aborting the session.
+
+set -euo pipefail
+
+VAULT="${1:-}"
+
+if [ -z "$VAULT" ]; then
+  echo "Configure vault path first: enable the plugin and enter your vault path when prompted"
+  exit 0
+fi
+
+# Locate the plugin root. Prefer CLAUDE_PLUGIN_ROOT when set (in-session).
+# Otherwise derive it from $0 so standalone invocations work.
+if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  SCRIPT_PATH=$(readlink -f "$0" 2>/dev/null || python3 -c "import os,sys;print(os.path.realpath(sys.argv[1]))" "$0")
+  CLAUDE_PLUGIN_ROOT=$(dirname "$(dirname "$SCRIPT_PATH")")
+  export CLAUDE_PLUGIN_ROOT
+fi
+
+bash "${CLAUDE_PLUGIN_ROOT}/bin/setup-vault.sh" "$VAULT"
+bash "${CLAUDE_PLUGIN_ROOT}/bin/copy-templates.sh" "$VAULT"
+
+cat <<EOF
+
+Next steps:
+  1. Open Obsidian → Manage Vaults → Open folder as vault → select: $VAULT
+  2. Enable community plugins when prompted, then install:
+       - Dataview
+       - Templater
+       - Obsidian Git
+  3. Run /wiki in Claude Code to scaffold your knowledge base.
+EOF

--- a/commands/wiki.md
+++ b/commands/wiki.md
@@ -9,35 +9,21 @@ If the argument is `init`, run the **INIT** operation below. Otherwise, run the 
 
 ## INIT
 
-1. Resolve the vault path from `${user_config.vault_path}`. If it is empty, print exactly this line and stop without error:
+Seed the configured Obsidian vault. One-shot, idempotent; does not scaffold the knowledge base (that is `/wiki`).
 
-   ```
-   Configure vault path first: enable the plugin and enter your vault path when prompted
-   ```
+Run:
 
-2. Run the setup script:
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/bin/wiki-init.sh" "${user_config.vault_path}"
+```
 
-   ```bash
-   bash "${CLAUDE_PLUGIN_ROOT}/bin/setup-vault.sh" "${user_config.vault_path}"
-   ```
+The script handles everything:
 
-3. Copy the plugin's `_templates/` into the vault, skipping existing files so the step is idempotent:
+- If `${user_config.vault_path}` is empty, prints `Configure vault path first: enable the plugin and enter your vault path when prompted` and exits 0.
+- Delegates to `bin/setup-vault.sh` (vault directories + Obsidian config) and `bin/copy-templates.sh` (idempotent template copy).
+- Prints the next steps (open Obsidian, install Dataview/Templater/Obsidian Git, run `/wiki` to scaffold).
 
-   ```bash
-   mkdir -p "${user_config.vault_path}/_templates"
-   for src in "${CLAUDE_PLUGIN_ROOT}/_templates/"*.md; do
-     dst="${user_config.vault_path}/_templates/$(basename "$src")"
-     [ -e "$dst" ] || cp "$src" "$dst"
-   done
-   ```
-
-4. Print next steps:
-
-   - Open Obsidian → *Manage Vaults* → *Open folder as vault* and select `${user_config.vault_path}`.
-   - Enable community plugins when prompted, then install **Dataview**, **Templater**, and **Obsidian Git** from Settings → Community Plugins.
-   - Run `/wiki` to scaffold your knowledge base.
-
-Re-running `/wiki init` must be idempotent: `setup-vault.sh` already guards existing files, and `cp -n` skips templates that are already in the vault.
+Surface the script's stdout to the user verbatim.
 
 ## SCAFFOLD (default)
 

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -116,31 +116,22 @@ Route to the correct operation based on what the user says:
 
 Trigger: `/wiki init`, "init vault", "bootstrap vault".
 
-Goal: seed an empty vault from `${user_config.vault_path}` so the user can open it in Obsidian. This is a one-shot, idempotent bootstrap — it does not ask questions and does not scaffold the knowledge base (that is SCAFFOLD).
+Goal: seed an empty vault from `${user_config.vault_path}` so the user can open it in Obsidian. One-shot, idempotent; does not scaffold the knowledge base (that is SCAFFOLD).
 
-Steps:
+Delegate to the umbrella script:
 
-1. Resolve `${user_config.vault_path}`. If empty, print:
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/bin/wiki-init.sh" "${user_config.vault_path}"
+```
 
-   `Configure vault path first: enable the plugin and enter your vault path when prompted`
+`bin/wiki-init.sh` handles the full flow:
 
-   Then stop without error.
+1. If the vault path argument is empty, prints `Configure vault path first: enable the plugin and enter your vault path when prompted` and exits 0 — no error, no further action.
+2. Calls `bin/setup-vault.sh` to create `.obsidian/`, `.raw/`, `wiki/`, `_templates/` and the Obsidian config files.
+3. Calls `bin/copy-templates.sh` to copy `_templates/*.md` into the vault, skipping files that already exist.
+4. Prints next steps: open Obsidian at the vault path, enable community plugins (Dataview, Templater, Obsidian Git), then run `/wiki` to scaffold the knowledge base.
 
-2. Run `bash "${CLAUDE_PLUGIN_ROOT}/bin/setup-vault.sh" "${user_config.vault_path}"` — creates `.obsidian/`, `.raw/`, `wiki/`, `_templates/` and the Obsidian config files.
-
-3. Copy templates from the plugin into the vault, skipping existing files:
-
-   ```bash
-   mkdir -p "${user_config.vault_path}/_templates"
-   for src in "${CLAUDE_PLUGIN_ROOT}/_templates/"*.md; do
-     dst="${user_config.vault_path}/_templates/$(basename "$src")"
-     [ -e "$dst" ] || cp "$src" "$dst"
-   done
-   ```
-
-4. Print next steps: open Obsidian at the vault path, enable community plugins (Dataview, Templater, Obsidian Git), then run `/wiki` to scaffold the knowledge base.
-
-Re-running is idempotent: `setup-vault.sh` guards existing files and the copy loop skips templates already present.
+Re-running is safe: every step guards existing files.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to the already-merged #18. Addresses two review comments asking that the inline bash in the INIT markdown be extracted into standalone scripts:

- https://github.com/misiekhardcore/claude-obsidian/pull/18#discussion_r3119921770 — `commands/wiki.md:20` — "can we have all these scripts as separate sh files?"
- https://github.com/misiekhardcore/claude-obsidian/pull/18#discussion_r3119927085 — `skills/wiki/SKILL.md:133` — "scripts should go to separate files"

Since #18 was already squash-merged, this lands as a separate PR.

## Changes

- `bin/wiki-init.sh` — umbrella script for `/wiki init`. Handles empty-arg guard (prints the configured message and exits 0), delegates to `setup-vault.sh` + `copy-templates.sh`, prints next steps.
- `bin/copy-templates.sh` — idempotent copy of `_templates/*.md` into `$VAULT/_templates/`. Skips existing files.
- Both scripts use the `CLAUDE_PLUGIN_ROOT` path-discovery fallback from `bin/wiki-lint-cron.sh` (#19), so they work when invoked standalone.
- `commands/wiki.md` and `skills/wiki/SKILL.md` — the INIT blocks collapse to a single `bash "${CLAUDE_PLUGIN_ROOT}/bin/wiki-init.sh" "${user_config.vault_path}"` invocation. Prose explanation retained.

## Test plan

- [x] `bash bin/wiki-init.sh ""` prints the "configure vault path" message and exits 0.
- [x] First invocation against a fresh `/tmp` vault creates the full structure; `diff -r _templates $VAULT/_templates` matches.
- [x] Second invocation is idempotent (no diffs, no errors).
- [x] `unset CLAUDE_PLUGIN_ROOT; bash bin/wiki-init.sh /tmp/...` — standalone invocation still resolves the plugin root via `$0`.
- [ ] End-to-end: run `/wiki init` in Claude Code with `vault_path` set, confirm next-steps print.