### PR TITLE
docs(readme): add install, skills, and vault structure sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,40 @@
 
 Obsidian wiki plugin for Claude Code — personal knowledge vault with LLM-assisted ingestion, research, and retrieval.
 
+## Install
+
+```bash
+claude plugin marketplace add misiekhardcore/claude-obsidian
+claude plugin install claude-obsidian@claude-obsidian
+```
+
+Then enable the plugin and set `vault_path` (absolute path to your Obsidian vault) when Claude Code prompts for user configuration.
+
+## Skills
+
+- `wiki` — bootstrap / health-check the vault
+- `ingest` — parallel batch ingestion of sources
+- `query` — answer questions from vault content
+- `lint` — find orphan pages, dead links, stale claims
+- `save` — save the current conversation or insight into the vault
+- `autoresearch` — autonomous iterative research loop
+- `canvas` — create / update Obsidian canvas files
+- `defuddle` — strip clutter from web pages before ingestion
+- `obsidian-markdown` — correct Obsidian-flavored Markdown (wikilinks, embeds, callouts)
+- `obsidian-bases` — create / edit `.base` files
+
+## Vault structure
+
+```
+<vault_path>/
+  wiki/          agent-generated knowledge (hot.md, index.md, concepts/, entities/, sources/)
+  .raw/          immutable source documents + .manifest.json
+  _templates/    Obsidian Templater templates
+  _attachments/  images + PDFs referenced by wiki pages
+  .obsidian/     (user-owned) Obsidian app config
+  daily/         (optional) daily notes if the user enables them
+```
+
 ## Hooks
 
 The plugin wires several passive automations into every session via `hooks/hooks.json`. All of them resolve the vault path through `scripts/resolve-vault.sh` and silently skip if no vault is configured.


### PR DESCRIPTION
## Summary

Adds the three front-matter sections a new reader needs before the existing Hooks / Scheduled Maintenance content becomes useful:

- **Install** — marketplace `add` + `install` commands and the `vault_path` config hint.
- **Skills** — one-line description for each of the 10 on-disk skills (`wiki`, `ingest`, `query`, `lint`, `save`, `autoresearch`, `canvas`, `defuddle`, `obsidian-markdown`, `obsidian-bases`).
- **Vault structure** — fenced tree of `<vault_path>/` contents, including `.obsidian/` and optional `daily/`.

Inserted before `## Hooks`. Existing `## Hooks`, `## Scheduled Maintenance`, and `## More` sections are byte-identical.

## Manual testing

1. `git checkout 21-complete-readme-install-skills-vault`
2. Open `README.md` in a Markdown viewer (GitHub preview, VS Code preview, or `gh pr view --web`).
3. Confirm the section order top-to-bottom: tagline → Install → Skills → Vault structure → Hooks → Scheduled Maintenance → More.
4. Confirm the `## Skills` list contains exactly 10 bullets and each name matches a directory under `skills/` (`ls skills/`).
5. Confirm the `## Vault structure` fenced block renders the tree with `.obsidian/` and `daily/` lines and their parenthetical notes.
6. `git diff main...HEAD -- README.md` — confirm the diff is additive only (34 insertions, 0 deletions).

Closes #21