### PR TITLE
fix(hooks): pass vault_path as arg to resolve-vault.sh

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\" \"${user_config.vault_path}\") || exit 0; [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
           },
           {
             "type": "prompt",
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\" \"${user_config.vault_path}\") || exit 0; [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
           },
           {
             "type": "prompt",
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; [ -d \"$VAULT/.git\" ] && git -C \"$VAULT\" add wiki/ .raw/ 2>/dev/null && (git -C \"$VAULT\" diff --cached --quiet || git -C \"$VAULT\" commit -m \"wiki: auto-commit $(date '+%Y-%m-%d %H:%M')\" 2>/dev/null) || true"
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\" \"${user_config.vault_path}\") || exit 0; [ -d \"$VAULT/.git\" ] && git -C \"$VAULT\" add wiki/ .raw/ 2>/dev/null && (git -C \"$VAULT\" diff --cached --quiet || git -C \"$VAULT\" commit -m \"wiki: auto-commit $(date '+%Y-%m-%d %H:%M')\" 2>/dev/null) || true"
           },
           {
             "type": "command",
@@ -51,7 +51,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; [ -d \"$VAULT/wiki\" ] && [ -d \"$VAULT/.git\" ] && git -C \"$VAULT\" diff --name-only HEAD 2>/dev/null | grep -q '^wiki/' && echo 'WIKI_CHANGED: Wiki pages were modified this session. Please update $VAULT/wiki/hot.md with a brief summary of what changed (under 500 words). Use the hot cache format: Last Updated, Key Recent Facts, Recent Changes, Active Threads. Keep it factual. Overwrite the file completely. It is a cache, not a journal.' || true"
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\" \"${user_config.vault_path}\") || exit 0; [ -d \"$VAULT/wiki\" ] && [ -d \"$VAULT/.git\" ] && git -C \"$VAULT\" diff --name-only HEAD 2>/dev/null | grep -q '^wiki/' && echo 'WIKI_CHANGED: Wiki pages were modified this session. Please update $VAULT/wiki/hot.md with a brief summary of what changed (under 500 words). Use the hot cache format: Last Updated, Key Recent Facts, Recent Changes, Active Threads. Keep it factual. Overwrite the file completely. It is a cache, not a journal.' || true"
           }
         ]
       }

--- a/scripts/resolve-vault.sh
+++ b/scripts/resolve-vault.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-VAULT="${user_config.vault_path}"
+VAULT="${1:-}"
 [ -z "$VAULT" ] && [ -d "$(pwd)/wiki" ] && VAULT="$(pwd)"
 if [ -z "$VAULT" ]; then
   echo "claude-obsidian: no vault configured — run /wiki init to set up" >&2


### PR DESCRIPTION
## Summary

`${user_config.vault_path}` is expanded by Claude Code only in hook command strings (in `hooks.json`), not in the contents of shell scripts. The current `resolve-vault.sh` had `VAULT="${user_config.vault_path}"` at the top — this never gets expanded and always produces an empty string, meaning vault resolution always fell through to the CWD fallback.

**Fix:** pass `${user_config.vault_path}` as `$1` from each hook command in `hooks.json`, and update `resolve-vault.sh` to read from `$1`.

## Changes

- `hooks/hooks.json` — all 4 `resolve-vault.sh` calls now pass `"${user_config.vault_path}"` as the first argument
- `scripts/resolve-vault.sh` — `VAULT="${user_config.vault_path}"` → `VAULT="${1:-}"`

## Manual testing

```bash
bash -n scripts/resolve-vault.sh          # ✓ syntax OK
jq . hooks/hooks.json >/dev/null          # ✓ JSON valid
```

Discovered during misiekhardcore/claude-config#17 migration.