### PR TITLE
fix(hooks): drop ${user_config.vault_path} from hook commands

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\" \"${user_config.vault_path}\") || exit 0; [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
           },
           {
             "type": "prompt",
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\" \"${user_config.vault_path}\") || exit 0; [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
           },
           {
             "type": "prompt",
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\" \"${user_config.vault_path}\") || exit 0; [ -d \"$VAULT/.git\" ] && git -C \"$VAULT\" add wiki/ .raw/ 2>/dev/null && (git -C \"$VAULT\" diff --cached --quiet || git -C \"$VAULT\" commit -m \"wiki: auto-commit $(date '+%Y-%m-%d %H:%M')\" 2>/dev/null) || true"
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; [ -d \"$VAULT/.git\" ] && git -C \"$VAULT\" add wiki/ .raw/ 2>/dev/null && (git -C \"$VAULT\" diff --cached --quiet || git -C \"$VAULT\" commit -m \"wiki: auto-commit $(date '+%Y-%m-%d %H:%M')\" 2>/dev/null) || true"
           },
           {
             "type": "command",
@@ -51,7 +51,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\" \"${user_config.vault_path}\") || exit 0; [ -d \"$VAULT/wiki\" ] && [ -d \"$VAULT/.git\" ] && git -C \"$VAULT\" diff --name-only HEAD 2>/dev/null | grep -q '^wiki/' && echo 'WIKI_CHANGED: Wiki pages were modified this session. Please update $VAULT/wiki/hot.md following the hot-cache protocol at ${CLAUDE_PLUGIN_ROOT}/_shared/hot-cache-protocol.md (under 500 words; sections: Last Updated, Key Recent Facts, Recent Changes, Active Threads; overwrite completely; factual cache, not a journal).' || true"
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; [ -d \"$VAULT/wiki\" ] && [ -d \"$VAULT/.git\" ] && git -C \"$VAULT\" diff --name-only HEAD 2>/dev/null | grep -q '^wiki/' && echo 'WIKI_CHANGED: Wiki pages were modified this session. Please update $VAULT/wiki/hot.md following the hot-cache protocol at ${CLAUDE_PLUGIN_ROOT}/_shared/hot-cache-protocol.md (under 500 words; sections: Last Updated, Key Recent Facts, Recent Changes, Active Threads; overwrite completely; factual cache, not a journal).' || true"
           }
         ]
       }

--- a/scripts/resolve-vault.sh
+++ b/scripts/resolve-vault.sh
@@ -1,24 +1,38 @@
 #!/usr/bin/env bash
+# Resolve the vault path in priority order:
+#   1. $1 argument (legacy; no longer passed by hooks as of #36)
+#   2. $(pwd) if it contains a wiki/ subdirectory
+#   3. ~/.claude/settings.local.json  (pluginConfigs[*claude-obsidian*].options.vault_path)
+#   4. ~/.claude/settings.json        (same key, userSettings scope written by /plugin manage)
 VAULT="${1:-}"
 [ -z "$VAULT" ] && [ -d "$(pwd)/wiki" ] && VAULT="$(pwd)"
-if [ -z "$VAULT" ] && [ -f "$HOME/.claude/settings.local.json" ]; then
+
+read_vault_from_settings() {
+  local file="$1"
+  [ -f "$file" ] || return 0
   if command -v jq >/dev/null 2>&1; then
-    VAULT=$(jq -r '(.pluginConfigs // {}) | to_entries[] | select(.key | contains("claude-obsidian")) | .value.options.vault_path // empty' "$HOME/.claude/settings.local.json" 2>/dev/null | head -1)
+    jq -r '(.pluginConfigs // {}) | to_entries[] | select(.key | contains("claude-obsidian")) | .value.options.vault_path // empty' "$file" 2>/dev/null | head -1
   elif command -v python3 >/dev/null 2>&1; then
-    VAULT=$(python3 -c "
-import json, sys
+    SETTINGS_FILE="$file" python3 -c '
+import json, os
 try:
-    with open('$HOME/.claude/settings.local.json') as f:
+    with open(os.environ["SETTINGS_FILE"]) as f:
         d = json.load(f)
-    for k, v in d.get('pluginConfigs', {}).items():
-        if 'claude-obsidian' in k:
-            print(v.get('options', {}).get('vault_path', ''))
+    for k, v in d.get("pluginConfigs", {}).items():
+        if "claude-obsidian" in k:
+            print(v.get("options", {}).get("vault_path", ""))
             break
 except Exception:
     pass
-" 2>/dev/null)
+' 2>/dev/null
   fi
-fi
+}
+
+for settings_file in "$HOME/.claude/settings.local.json" "$HOME/.claude/settings.json"; do
+  [ -n "$VAULT" ] && break
+  VAULT=$(read_vault_from_settings "$settings_file")
+done
+
 if [ -z "$VAULT" ]; then
   echo "claude-obsidian: no vault configured — run /wiki init to set up" >&2
   exit 1


### PR DESCRIPTION
## Summary

- `hooks/hooks.json` — remove `\"${user_config.vault_path}\"` from all four hook command invocations (SessionStart, PostCompact, PostToolUse, Stop). Hooks now call `resolve-vault.sh` with no argument.
- `scripts/resolve-vault.sh` — factor the jq/python3 settings-reader into a helper and apply it to both `~/.claude/settings.local.json` and `~/.claude/settings.json`. Priority order is documented in the script header.

## Why

The Claude Code harness (v2.1.118) expands `${user_config.*}` in hook `command` strings before invoking bash. If the value is unset in userSettings (`~/.claude/settings.json`) it throws `Plugin option "vault_path" isn't set…` and the hook never runs. Users who put their pluginConfigs in `~/.claude/settings.local.json`, or who haven't run `/plugin manage` yet, hit this on every Stop / SessionStart.

The existing settings.local.json fallback (#31 / PRs #32, #33) only helps out-of-session callers (cron/systemd). In-session hooks never reach the script because substitution fails first. By removing the substitution from hook commands and letting the script walk the resolution chain itself, the fallback applies to both in-session and out-of-session paths.

`userConfig.vault_path` stays in `plugin.json` — it still powers the `/plugin manage` UX and keeps the value flowing into settings.json.

## Out of scope

`${user_config.vault_path}` still appears in `skills/wiki/SKILL.md` and `commands/wiki.md`. These go through the skill-content substitution path (`$U$` in the harness), which is non-fatal — it leaves the literal placeholder in place if unset rather than erroring. Separate cleanup; not part of #36.

## Manual testing

Covered by the five ACs in #36 plus python3 fallback:

| Case | Expected | Result |
|---|---|---|
| `$1` arg given | echoes arg | ✅ |
| CWD has `wiki/`, no arg | echoes CWD | ✅ |
| AC1: vault_path only in `~/.claude/settings.local.json` | resolves to that path | ✅ |
| AC2: vault_path only in `~/.claude/settings.json` | resolves to that path | ✅ |
| AC3: out-of-session (cron) with settings.json | resolves (same code path) | ✅ |
| AC4: nothing configured, no `wiki/` in CWD | exits 1 with existing message | ✅ |
| AC5: `hooks.json` is valid JSON, no `${user_config.*}` remaining | confirmed | ✅ |
| settings.local.json beats settings.json when both set | local wins | ✅ |
| python3 fallback path (jq stripped from PATH) | both files still resolvable | ✅ |

### Repro steps

1. `git checkout fix/36-hook-substitution-fallback`
2. `bash -n scripts/resolve-vault.sh && python3 -c \"import json; json.load(open('hooks/hooks.json'))\"` — syntax + JSON valid
3. Create a throwaway `\$HOME` with only `.claude/settings.local.json` containing the pluginConfigs block pointing at any absolute path; run `HOME=<throwaway> scripts/resolve-vault.sh` — should echo the path.
4. Repeat with `.claude/settings.json` instead — same result.
5. Neither file present, no `wiki/` in CWD — exits 1 with the "no vault configured" message.

Closes #36