### PR TITLE
feat(lint): add hot.md size budget check

### DIFF
--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -26,6 +26,10 @@ Work through these in order:
 6. **Frontmatter gaps**. Pages missing required fields (type, status, created, updated, tags).
 7. **Empty sections**. Headings with no content underneath.
 8. **Stale index entries**. Items in `wiki/index.md` pointing to renamed or deleted pages.
+9. **hot.md size budget**. Count words in `wiki/hot.md`.
+   - **WARN** if word count > 500 (spec limit per `_shared/hot-cache-protocol.md`).
+   - **FAIL** if word count > 750 (50 % buffer exceeded).
+   - Remediation: move entries older than 2 weeks to `wiki/log.md`; trim `## Last Updated` to the 3–5 most recent items.
 
 ---
 
@@ -68,6 +72,10 @@ status: developing
 
 ## Cross-Reference Gaps
 - [[Entity Name]] mentioned in [[Page A]] without a wikilink.
+
+## Hot Cache Size
+- hot.md: N words (spec: 500, delta: +N). Status: OK | WARN | FAIL
+  - Suggest: move entries older than 2026-XX-XX to [[log]], trim ## Last Updated to top 3–5 items.
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Adds check #9 to `skills/lint/SKILL.md`: flags `wiki/hot.md` when word count drifts beyond the ~500-word spec
- WARN threshold: > 500 words; FAIL threshold: > 750 words (50% buffer)
- Lint report template gains a `## Hot Cache Size` section showing word count, delta from spec, and remediation guidance
- Remediation: move aged entries (> 2 weeks) to `wiki/log.md`; trim `## Last Updated` to top 3–5 items

Closes #24

## Manual testing

1. Open a vault where `wiki/hot.md` exists with > 500 words (the `misiekhardcore` vault currently has 577 words).
2. Run `/lint` or "health check".
3. Verify the lint report at `wiki/meta/lint-report-YYYY-MM-DD.md` includes a `## Hot Cache Size` section.
4. Confirm the section shows the word count, `delta: +N`, and `Status: WARN`.
5. For FAIL threshold test: temporarily pad `hot.md` past 750 words and re-run lint; confirm `Status: FAIL`.
6. For a clean vault (hot.md ≤ 500 words): confirm `Status: OK` and no issue is raised in the Summary.