### PR TITLE
feat(notes): add /note skill for inbox capture and triage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ wiki/              Claude-generated knowledge base
   concepts/        Conceptual deep-dives
   entities/        Reference material (people, organizations, tools)
   sources/         Summaries linked to original materials
+notes/             Inbox: verbatim quick-capture notes (owned by `notes` skill)
+  index.md         Pending + Deferred bullet list
 .raw/              Source documents — immutable, never modified by agents
 _templates/        Obsidian Templater templates
 _attachments/      Images and PDFs referenced by wiki pages
@@ -64,6 +66,7 @@ All skills live in `skills/<name>/SKILL.md` and are auto-discovered by Claude Co
 | `query` | query, what do you know about, query quick:, query deep: |
 | `lint` | lint the wiki, health check, find orphans, dead links |
 | `save` | `/save`, file this conversation, save insight |
+| `notes` | `/note`, `/dump`, note this, todo:, show my inbox, `/note process` |
 | `autoresearch` | autoresearch, autonomous research loop |
 | `canvas` | `/canvas`, add to canvas, create canvas |
 | `defuddle` | clean this url, defuddle, strip clutter |

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Then enable the plugin and set `vault_path` (absolute path to your Obsidian vaul
 - `query` — answer questions from vault content
 - `lint` — find orphan pages, dead links, stale claims
 - `save` — save the current conversation or insight into the vault
+- `notes` — quick inbox capture (`/note`, `/dump`); list and process flows for triage
 - `autoresearch` — autonomous iterative research loop
 - `canvas` — create / update Obsidian canvas files
 - `defuddle` — strip clutter from web pages before ingestion
@@ -29,6 +30,7 @@ Then enable the plugin and set `vault_path` (absolute path to your Obsidian vaul
 ```
 <vault_path>/
   wiki/          agent-generated knowledge (hot.md, index.md, concepts/, entities/, sources/)
+  notes/         inbox: verbatim quick-capture notes (owned by `notes` skill)
   .raw/          immutable source documents + .manifest.json
   _templates/    Obsidian Templater templates
   _attachments/  images + PDFs referenced by wiki pages

--- a/_seed/notes/index.md
+++ b/_seed/notes/index.md
@@ -7,6 +7,10 @@ tags:
   - meta
   - notes
 status: evergreen
+confidence: EXTRACTED
+evidence: []
+related:
+  - "[[wiki/index]]"
 ---
 
 # Notes Inbox

--- a/_seed/notes/index.md
+++ b/_seed/notes/index.md
@@ -1,0 +1,22 @@
+---
+type: meta
+title: "Notes Inbox"
+created: {{today}}
+updated: {{today}}
+tags:
+  - meta
+  - notes
+status: evergreen
+---
+
+# Notes Inbox
+
+Captured notes pending processing. Maintained by `skills/notes`.
+
+## Pending
+
+<!-- New captures prepend here. Format: - [ ] YYYY-MM-DD [source_project] title -->
+
+## Deferred
+
+<!-- Notes flipped to status: deferred move here. Format: - [~] YYYY-MM-DD [source_project] title -->

--- a/commands/dump.md
+++ b/commands/dump.md
@@ -3,6 +3,6 @@ description: Dump a verbatim thought into the notes inbox. Alias for /note <text
 argument-hint: "<verbatim text>"
 ---
 
-Read the `notes` skill, then run the CAPTURE operation with the argument as the verbatim text. Same behaviour as `/note <text>` — silent auto-match append on overlap, silent file creation on no match. No prompts.
+Read the `notes` skill. Then run the CAPTURE operation with the argument as the verbatim text. Same behaviour as `/note <text>` — silent auto-match append on overlap, silent file creation on no match. No prompts.
 
 If the argument is empty, surface: `Usage: /dump <verbatim text>`. If no vault is configured, surface: `No vault configured — run /wiki init first.`

--- a/commands/dump.md
+++ b/commands/dump.md
@@ -1,0 +1,8 @@
+---
+description: Dump a verbatim thought into the notes inbox. Alias for /note <text>.
+argument-hint: "<verbatim text>"
+---
+
+Read the `notes` skill, then run the CAPTURE operation with the argument as the verbatim text. Same behaviour as `/note <text>` — silent auto-match append on overlap, silent file creation on no match. No prompts.
+
+If the argument is empty, surface: `Usage: /dump <verbatim text>`. If no vault is configured, surface: `No vault configured — run /wiki init first.`

--- a/commands/note.md
+++ b/commands/note.md
@@ -1,0 +1,20 @@
+---
+description: Capture a quick inbox note (or list/process the inbox) without breaking flow.
+argument-hint: "[list|process|<verbatim text>]"
+---
+
+Read the `notes` skill. Then dispatch based on the argument:
+
+- `/note <text>` — capture mode. Pass the verbatim text to the skill's CAPTURE operation. Do not rewrite, summarise, or tag.
+- `/note list [--project=<basename>]` — LIST operation. Show pending + deferred notes; honour the project filter.
+- `/note process [--include-deferred]` — PROCESS operation. Walk pending notes one at a time; route each to `/save`, defer, or delete.
+
+If the argument is empty (`/note` alone), show usage:
+
+```
+/note <text>           Capture a verbatim note to the inbox
+/note list             Show the inbox
+/note process          Triage the inbox
+```
+
+If no vault is configured, surface: `No vault configured — run /wiki init first.`

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -30,6 +30,10 @@ Work through these in order:
    - **WARN** if word count > 500 (spec limit per `_shared/hot-cache-protocol.md`).
    - **FAIL** if word count > 750 (50 % buffer exceeded).
    - Remediation: move entries older than 2 weeks to `wiki/log.md`; trim `## Last Updated` to the 3–5 most recent items.
+10. **Notes inbox**. Scoped to `<vault_root>/notes/` only. Two checks:
+    - **Frontmatter gaps** — flag any `notes/*.md` (excluding `notes/index.md`) missing one of: `type`, `title`, `created`, `updated`, `source_project`, `status`. The `topic` and `tags` fields are optional and never flagged.
+    - **Index drift** — flag any file in `notes/` that is missing from `notes/index.md`, and any row in `notes/index.md` whose `<title>` doesn't resolve to an existing file.
+    - **Explicitly skip** orphan checks, dead-link checks, stale-claim checks, and contradictions for `notes/`. These are wiki-canonical concerns and inappropriate for a transient inbox.
 
 ---
 
@@ -76,6 +80,17 @@ status: developing
 ## Hot Cache Size
 - hot.md: N words (spec: 500, delta: +N). Status: OK | WARN | FAIL
   - Suggest: move entries older than 2026-XX-XX to [[log]], trim ## Last Updated to top 3–5 items.
+
+## Notes Inbox
+
+Scope: `notes/` only. Frontmatter gaps and index drift; no orphan/dead-link/stale checks.
+
+### Frontmatter gaps
+- `notes/<filename>.md`: missing fields: <field>, <field>
+
+### Index drift
+- File missing from index: `notes/<filename>.md` (no row in `notes/index.md`)
+- Index row missing file: `notes/index.md` references "<title>" but no file resolves to it
 ```
 
 ---

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -32,7 +32,7 @@ Work through these in order:
    - Remediation: move entries older than 2 weeks to `wiki/log.md`; trim `## Last Updated` to the 3–5 most recent items.
 10. **Notes inbox**. Scoped to `<vault_root>/notes/` only. Two checks:
     - **Frontmatter gaps** — flag any `notes/*.md` (excluding `notes/index.md`) missing one of: `type`, `title`, `created`, `updated`, `source_project`, `status`. The `topic` and `tags` fields are optional and never flagged.
-    - **Index drift** — flag any file in `notes/` that is missing from `notes/index.md`, and any row in `notes/index.md` whose `<title>` doesn't resolve to an existing file.
+    - **Index drift** — flag any file in `notes/` that is missing from `notes/index.md`, and any row in `notes/index.md` whose title text doesn't match any existing note's frontmatter `title:` field. Match against frontmatter `title:`, not filenames — filenames are slugs that may diverge from display titles after CAPTURE rewrites (AC4).
     - **Explicitly skip** orphan checks, dead-link checks, stale-claim checks, and contradictions for `notes/`. These are wiki-canonical concerns and inappropriate for a transient inbox.
 
 ---

--- a/skills/notes/SKILL.md
+++ b/skills/notes/SKILL.md
@@ -7,8 +7,9 @@ description: >
   flows for triaging the inbox later. Triggers on: "/note", "/dump",
   "note this", "remember this for later", "add to inbox", "todo:",
   "show my inbox", "/note list", "what's in notes",
-  "/note process", "process my notes", "process the inbox".
-allowed-tools: Read Write Edit Glob Grep
+  "/note process", "process my notes", "process the inbox",
+  "triage the inbox".
+allowed-tools: Read Write Edit Glob Grep Bash
 ---
 
 # notes: Inbox Capture for the Vault
@@ -29,11 +30,11 @@ If no vault is configured, abort with `No vault configured — run /wiki init fi
 
 ## Operations
 
-| User says | Operation |
-|-----------|-----------|
-| `/note <text>`, `/dump <text>`, "note this …", "remember this for later", "add to inbox …", "todo: …" | CAPTURE |
-| `/note list`, "show my inbox", "what's in notes" | LIST |
-| `/note process`, "process my notes", "triage the inbox" | PROCESS |
+| User says | Operation | Handled by |
+|-----------|-----------|------------|
+| `/note <text>`, `/dump <text>`, "note this …", "remember this for later", "add to inbox …", "todo: …" | CAPTURE | this skill |
+| `/note list`, "show my inbox", "what's in notes" | LIST | this skill |
+| `/note process`, "process my notes", "triage the inbox" | PROCESS | this skill |
 
 Capture, list, and process do not prompt for tags, types, or confirmations beyond the per-note action prompt in PROCESS.
 
@@ -46,8 +47,8 @@ Goal: persist the user's verbatim text with minimal metadata. No conversation co
 Steps:
 
 1. **Extract** the verbatim text from the user's message. For `/note <text>` and `/dump <text>`, the text is everything after the trigger. For natural-language triggers (`"note this: …"`, `"todo: …"`), extract the substring after the trigger phrase. Preserve the original wording exactly — no rewriting, no summarising.
-2. **Resolve** `<vault_root>` (see Vault path). Compute today's date as `YYYY-MM-DD`. Compute `source_project = basename(cwd)`.
-3. **Enumerate** existing notes by listing `<vault_root>/notes/*.md` and reading **frontmatter only** for each (title, topic, tags). Skip bodies — they bloat the prompt and aren't needed for the match decision. Skip `notes/index.md` and any file with `status: deferred`.
+2. **Resolve** `<vault_root>` (see Vault path). Compute today's date as `YYYY-MM-DD`. Compute `source_project = basename(cwd)`. If `<vault_root>/notes/` does not exist, create the directory and initialise `notes/index.md` from the template in the `## notes/index.md` section below; then continue.
+3. **Enumerate** existing notes by listing `<vault_root>/notes/*.md` and reading **frontmatter only** for each (title, topic, tags). Skip bodies — they bloat the prompt and aren't needed for the match decision. Skip `notes/index.md` and any file with `status: deferred`. (Deferred notes are excluded intentionally: the user set them aside; routing new content into them would silently overturn that decision.)
 4. **Decide MATCH or NEW** using the prompt template below. The bar is intentionally high; misroutes cost more than duplicates because the user does not see the decision at capture time.
 5. **MATCH path** — append to the existing file:
    - Add a separator + the new verbatim chunk to the body:
@@ -67,7 +68,7 @@ Steps:
    - For NEW captures the title is the user's text trimmed to a one-line summary (≤80 chars). If the verbatim text is itself short and one-line, use it as the title. Topic and tags may be left empty (`""` and `[]`) — they're populated by the user later if needed.
 7. **Update `notes/index.md`** — patch in place, no full rewrite:
    - On NEW: prepend a row under `## Pending`.
-   - On MATCH: bump the existing row's date to today; if the title was rewritten, replace the title text. Never add a duplicate row.
+   - On MATCH: find the existing row by the **pre-rewrite title** (the title the file had before this operation). Bump its date to today; if the title was rewritten, replace the title text. Never add a duplicate row.
    - Format: `- [ ] YYYY-MM-DD [<source_project>] <title>`.
 8. **Confirm** with one terse line. Two shapes only:
    - NEW: `Captured to notes/YYYY-MM-DD-<slug>.md`
@@ -135,7 +136,7 @@ Goal: walk pending notes one at a time and route each to `/save`, defer, or dele
 
 Steps:
 
-1. Enumerate pending notes (skip `status: deferred` unless `--include-deferred`). Sort by `updated` ascending — oldest first.
+1. Enumerate pending notes (skip `status: deferred` unless `--include-deferred`). Sort by `updated` ascending — oldest first. If there are no notes to process, print `Inbox is empty.` and exit.
 2. For each note, read full frontmatter + body and display:
    ```
    [N/total] YYYY-MM-DD [source_project]
@@ -146,7 +147,7 @@ Steps:
    Action? [s]ave / [d]efer / [x]delete / [q]uit
    ```
 3. Wait for the user's single-letter action. Loop on invalid input.
-4. **`s` (save)** — invoke the `save` skill via the Skill tool, passing the note body + frontmatter as input. On success:
+4. **`s` (save)** — invoke the `save` skill via the Skill tool, passing the note body, the frontmatter, and an explicit note name: `"Save this as: <title>"` so the save skill's step 2 name-prompt is pre-satisfied and the interactive loop is not broken. On success:
    - Delete `<vault_root>/notes/<filename>`.
    - Remove the corresponding row from `notes/index.md`.
    On `/save` failure, leave the note untouched and surface the error.
@@ -159,7 +160,7 @@ Steps:
 
 ---
 
-## Frontmatter template
+## Frontmatter Template
 
 ```yaml
 ---
@@ -198,6 +199,10 @@ tags:
   - meta
   - notes
 status: evergreen
+confidence: EXTRACTED
+evidence: []
+related:
+  - "[[wiki/index]]"
 ---
 
 # Notes Inbox
@@ -242,8 +247,8 @@ Out of scope:
 
 **Capture (NEW):**
 ```
-user> /note process should reuse confidence threshold from save
-assistant> Captured to notes/2026-04-25-process-should-reuse-confidence-threshold-from-save.md
+user> /note inbox count missing from /wiki status
+assistant> Captured to notes/2026-04-25-inbox-count-missing-from-wiki-status.md
 ```
 
 **Capture (MATCH-append, scope unchanged):**

--- a/skills/notes/SKILL.md
+++ b/skills/notes/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: notes
+description: >
+  Capture quick inbox notes into the vault without breaking flow. Verbatim
+  capture, silent auto-match append on overlap, silent file creation on no
+  match. Per-project filtering via source_project. Listing and processing
+  flows for triaging the inbox later. Triggers on: "/note", "/dump",
+  "note this", "remember this for later", "add to inbox", "todo:",
+  "show my inbox", "/note list", "what's in notes",
+  "/note process", "process my notes", "process the inbox".
+allowed-tools: Read Write Edit Glob Grep
+---
+
+# notes: Inbox Capture for the Vault
+
+Some thoughts shouldn't interrupt the work to write a real wiki page. A bug in tooling. A follow-up for another project. "This didn't work, revisit later." This skill catches them, verbatim, and files them in `<vault_root>/notes/` without prompts. Triage happens later.
+
+The wiki is the polished knowledge base. `notes/` is the inbox. Keep them separate. `/save` files synthesised pages; `/note` files raw thoughts.
+
+---
+
+## Vault path
+
+Resolve `<vault_root>` exactly the same way `wiki` does — project setting `claude-obsidian.vault_path` first, then CWD if it contains `wiki/`, then settings files via `${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh`. **Always write to `<vault_root>/notes/`** regardless of CWD. The `source_project` field records where the user was when capturing.
+
+If no vault is configured, abort with `No vault configured — run /wiki init first.`
+
+---
+
+## Operations
+
+| User says | Operation |
+|-----------|-----------|
+| `/note <text>`, `/dump <text>`, "note this …", "remember this for later", "add to inbox …", "todo: …" | CAPTURE |
+| `/note list`, "show my inbox", "what's in notes" | LIST |
+| `/note process`, "process my notes", "triage the inbox" | PROCESS |
+
+Capture, list, and process do not prompt for tags, types, or confirmations beyond the per-note action prompt in PROCESS.
+
+---
+
+## CAPTURE Operation
+
+Goal: persist the user's verbatim text with minimal metadata. No conversation context, no auto-tagging, no questions.
+
+Steps:
+
+1. **Extract** the verbatim text from the user's message. For `/note <text>` and `/dump <text>`, the text is everything after the trigger. For natural-language triggers (`"note this: …"`, `"todo: …"`), extract the substring after the trigger phrase. Preserve the original wording exactly — no rewriting, no summarising.
+2. **Resolve** `<vault_root>` (see Vault path). Compute today's date as `YYYY-MM-DD`. Compute `source_project = basename(cwd)`.
+3. **Enumerate** existing notes by listing `<vault_root>/notes/*.md` and reading **frontmatter only** for each (title, topic, tags). Skip bodies — they bloat the prompt and aren't needed for the match decision. Skip `notes/index.md` and any file with `status: deferred`.
+4. **Decide MATCH or NEW** using the prompt template below. The bar is intentionally high; misroutes cost more than duplicates because the user does not see the decision at capture time.
+5. **MATCH path** — append to the existing file:
+   - Add a separator + the new verbatim chunk to the body:
+     ```
+     <existing body>
+
+     ---
+
+     <new verbatim text>
+     ```
+   - If the new content broadens the note's scope, **rewrite `title:`** to a phrase covering the union. Bump `updated:` to today. Frontmatter `topic:` and `tags:` may be widened as needed; never narrowed.
+   - **Filename is never renamed.** Drift between filename slug and rewritten `title` is acceptable.
+6. **NEW path** — create a new file:
+   - Slug from title: lowercase, non-alphanumerics → `-`, collapse runs, trim leading/trailing `-`, truncate to 40 chars. If a file with that name exists for today, append `-2`, `-3`, etc.
+   - Path: `<vault_root>/notes/YYYY-MM-DD-<slug>.md`.
+   - Frontmatter from the template below; body is the verbatim text.
+   - For NEW captures the title is the user's text trimmed to a one-line summary (≤80 chars). If the verbatim text is itself short and one-line, use it as the title. Topic and tags may be left empty (`""` and `[]`) — they're populated by the user later if needed.
+7. **Update `notes/index.md`** — patch in place, no full rewrite:
+   - On NEW: prepend a row under `## Pending`.
+   - On MATCH: bump the existing row's date to today; if the title was rewritten, replace the title text. Never add a duplicate row.
+   - Format: `- [ ] YYYY-MM-DD [<source_project>] <title>`.
+8. **Confirm** with one terse line. Two shapes only:
+   - NEW: `Captured to notes/YYYY-MM-DD-<slug>.md`
+   - MATCH: `Appended to notes/YYYY-MM-DD-<slug>.md`
+
+Do **not** print the diff, the match reasoning, or the candidate list. Capture is a fire-and-forget action.
+
+### Match prompt template
+
+When CAPTURE step 3 enumerates candidates, run this decision in your head before writing. Output exactly one of `MATCH: <filename> | <reason>` or `NEW`.
+
+```
+Existing notes (frontmatter only):
+{{for each candidate, render: filename, title, topic, tags}}
+
+New note text:
+"""
+{{verbatim user text}}
+"""
+
+Decide:
+- MATCH: <filename> | <one sentence why> — only if a single candidate clearly
+  extends or near-duplicates the new content. Required signals (ALL must hold):
+    1. (title alignment) OR (topic alignment) — same subject, not just same domain.
+    2. (tag overlap ≥ 1) OR (tags empty on both, AND title/topic alignment is strong).
+    3. The new content is a logical extension of the existing scope (continuation,
+       counter-example, follow-up question on the same thing) — not a new thread.
+- NEW — anything ambiguous, weak, cross-cutting, contradictory, or where two
+  candidates plausibly fit. The bar is high; default to NEW under doubt.
+```
+
+Use `MATCH` only when one candidate stands out clearly. If two candidates both look plausible, output `NEW` — duplicates are recoverable, misroutes are silent.
+
+---
+
+## LIST Operation
+
+Goal: show pending and deferred notes for triage.
+
+Steps:
+
+1. Read `<vault_root>/notes/*.md` frontmatter (title, source_project, status, updated). Skip `notes/index.md`.
+2. Sort by `updated` descending.
+3. Render flat reverse-chronological bullets:
+   ```
+   Pending notes (N):
+
+   - [ ] YYYY-MM-DD [source_project] title
+   - [ ] YYYY-MM-DD [source_project] title
+
+   Deferred (M):
+
+   - [~] YYYY-MM-DD [source_project] title
+   ```
+   Glyphs: `[ ]` pending, `[~]` deferred. Always include both sections; show `(none)` under a section that's empty.
+4. **Filter `--project=<basename>`** — when present, only show notes whose `source_project` matches. Honour the same flag in natural-language form (`"show my inbox for claude-obsidian"`).
+
+`/note list` includes pending + deferred. `/note process` iterates pending only by default; pass `--include-deferred` to walk both.
+
+---
+
+## PROCESS Operation
+
+Goal: walk pending notes one at a time and route each to `/save`, defer, or delete.
+
+Steps:
+
+1. Enumerate pending notes (skip `status: deferred` unless `--include-deferred`). Sort by `updated` ascending — oldest first.
+2. For each note, read full frontmatter + body and display:
+   ```
+   [N/total] YYYY-MM-DD [source_project]
+   title: <title>
+   body:
+   > <verbatim body, indented as a blockquote>
+
+   Action? [s]ave / [d]efer / [x]delete / [q]uit
+   ```
+3. Wait for the user's single-letter action. Loop on invalid input.
+4. **`s` (save)** — invoke the `save` skill via the Skill tool, passing the note body + frontmatter as input. On success:
+   - Delete `<vault_root>/notes/<filename>`.
+   - Remove the corresponding row from `notes/index.md`.
+   On `/save` failure, leave the note untouched and surface the error.
+5. **`d` (defer)** — patch the note's frontmatter: `status: deferred`, bump `updated:` to today. Move the row in `notes/index.md` from `## Pending` to `## Deferred`.
+6. **`x` (delete)** — delete the file unconditionally. Remove the corresponding row from `notes/index.md`.
+7. **`q` (quit)** — exit the loop. Remaining notes stay pending.
+8. After the loop, print a one-line summary: `Processed N notes: X saved, Y deferred, Z deleted.`
+
+`/save` handoff is the primary off-ramp. Defer is for notes that aren't actionable yet but may be later. Delete is for noise.
+
+---
+
+## Frontmatter template
+
+```yaml
+---
+type: note
+title: "<one-line summary, ≤80 chars>"
+topic: ""
+tags: []
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+source_project: "<cwd basename at capture time>"
+status: pending
+---
+```
+
+- `type: note` — additive value to the schema in `${CLAUDE_PLUGIN_ROOT}/_shared/frontmatter.md`. No schema change required.
+- `topic` — optional free-text grouping (e.g. `"vault tooling"`, `"workflow ergonomics"`). Empty by default.
+- `tags` — optional. Empty by default. Populated later by the user if useful.
+- `source_project` — basename of CWD at capture time. Used by `LIST --project=…`.
+- `status` — `pending` | `deferred`. New captures default to `pending`.
+
+The body is the user's verbatim text. No headings, no metadata in the body. On MATCH-append, the separator is a blank line + `---` + blank line, then the new verbatim chunk.
+
+---
+
+## `notes/index.md`
+
+Two static sections — `## Pending` and `## Deferred`. No project subgroups.
+
+```markdown
+---
+type: meta
+title: "Notes Inbox"
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+tags:
+  - meta
+  - notes
+status: evergreen
+---
+
+# Notes Inbox
+
+Captured notes pending processing. Maintained by `skills/notes`.
+
+## Pending
+
+- [ ] 2026-04-25 [claude-obsidian] /note process should reuse confidence threshold from save
+- [ ] 2026-04-24 [scripts] dependency upgrade leaves stale lockfile entries
+
+## Deferred
+
+- [~] 2026-04-22 [scripts] old idea, deferred — revisit Q3
+```
+
+Patch the index on every CAPTURE/PROCESS action — never re-render from scratch. Mirror the patch-in-place pattern used by `/save` and `/ingest`. The index is the single source of truth at this scale; `/wiki lint` is the safety net for drift.
+
+---
+
+## What is and isn't in scope
+
+In scope:
+- Verbatim capture with timestamp and `source_project` only.
+- Silent auto-match append on confident overlap.
+- Silent file creation on no match.
+- Title rewrite on scope-broadening append.
+- List + per-project filter.
+- Process loop with save / defer / delete / quit.
+
+Out of scope:
+- Modifying `/save`'s internals (handoff only).
+- GitHub-issue export as a processing target.
+- Auto-expiry, archival, or stale-note cleanup (`/wiki lint` reports drift only).
+- Capturing the previous assistant turn or any conversation context.
+- Manual tag prompts at capture time.
+- Confirmation prompts on capture (silent always).
+
+---
+
+## Examples
+
+**Capture (NEW):**
+```
+user> /note process should reuse confidence threshold from save
+assistant> Captured to notes/2026-04-25-process-should-reuse-confidence-threshold-from-save.md
+```
+
+**Capture (MATCH-append, scope unchanged):**
+```
+user> note this: still seeing the same flaky behaviour on macOS
+assistant> Appended to notes/2026-04-22-flaky-macos-runner.md
+```
+
+**Capture (MATCH-append with title rewrite):**
+```
+user> /dump same issue now reproduces on Linux too
+# existing note title was "flaky macOS runner"; new content broadens scope
+assistant> Appended to notes/2026-04-22-flaky-macos-runner.md
+# title rewritten to "flaky CI runner (macOS + Linux)", filename unchanged
+```
+
+**List, filtered:**
+```
+user> /note list --project=claude-obsidian
+assistant>
+Pending notes (2):
+
+- [ ] 2026-04-25 [claude-obsidian] /note process should reuse confidence threshold
+- [ ] 2026-04-24 [claude-obsidian] inbox count missing from /wiki status
+
+Deferred (1):
+
+- [~] 2026-04-12 [claude-obsidian] consider auto-tagging from CWD remote name
+```
+
+**Process:**
+```
+user> /note process
+assistant>
+[1/3] 2026-04-25 [claude-obsidian]
+title: /note process should reuse confidence threshold from save
+body:
+> /note process should reuse confidence threshold from save
+
+Action? [s]ave / [d]efer / [x]delete / [q]uit
+user> s
+# /save invoked, wiki page created, note removed from notes/
+assistant> Saved as [[Confidence threshold reuse]] in wiki/concepts/. Note deleted.
+```

--- a/skills/notes/SKILL.md
+++ b/skills/notes/SKILL.md
@@ -48,7 +48,7 @@ Steps:
 
 1. **Extract** the verbatim text from the user's message. For `/note <text>` and `/dump <text>`, the text is everything after the trigger. For natural-language triggers (`"note this: …"`, `"todo: …"`), extract the substring after the trigger phrase. Preserve the original wording exactly — no rewriting, no summarising.
 2. **Resolve** `<vault_root>` (see Vault path). Compute today's date as `YYYY-MM-DD`. Compute `source_project = basename(cwd)`. If `<vault_root>/notes/` does not exist, create the directory and initialise `notes/index.md` from the template in the `## notes/index.md` section below; then continue.
-3. **Enumerate** existing notes by listing `<vault_root>/notes/*.md` and reading **frontmatter only** for each (title, topic, tags). Skip bodies — they bloat the prompt and aren't needed for the match decision. Skip `notes/index.md` and any file with `status: deferred`. (Deferred notes are excluded intentionally: the user set them aside; routing new content into them would silently overturn that decision.)
+3. **Enumerate** existing notes by listing `<vault_root>/notes/*.md` and reading **frontmatter only** for each (title, topic, tags). Skip bodies — they bloat the prompt and aren't needed for the match decision. Skip `notes/index.md` and any file with `status: deferred`. (Deferred notes are excluded intentionally: the user set them aside; routing new content into them would silently overturn that decision.) Cap candidates at the **20 most recent by `updated:`** — older notes rarely match new captures and inflate the prompt. Use `mcp__obsidian-vault__obsidian_batch_get_file_contents` when the MCP server is available to read frontmatter in one call.
 4. **Decide MATCH or NEW** using the prompt template below. The bar is intentionally high; misroutes cost more than duplicates because the user does not see the decision at capture time.
 5. **MATCH path** — append to the existing file:
    - Add a separator + the new verbatim chunk to the body:
@@ -110,7 +110,7 @@ Goal: show pending and deferred notes for triage.
 
 Steps:
 
-1. Read `<vault_root>/notes/*.md` frontmatter (title, source_project, status, updated). Skip `notes/index.md`.
+1. Read `<vault_root>/notes/*.md` frontmatter (title, source_project, status, updated). Skip `notes/index.md`. Use `mcp__obsidian-vault__obsidian_batch_get_file_contents` when available — one batched read beats N sequential ones once the inbox grows past a handful of notes.
 2. Sort by `updated` descending.
 3. Render flat reverse-chronological bullets:
    ```
@@ -187,59 +187,16 @@ The body is the user's verbatim text. No headings, no metadata in the body. On M
 
 ## `notes/index.md`
 
-Two static sections — `## Pending` and `## Deferred`. No project subgroups.
+Canonical template lives at `_seed/notes/index.md` (copied during `/wiki init`). Two static sections — `## Pending` and `## Deferred`. No project subgroups.
 
-```markdown
----
-type: meta
-title: "Notes Inbox"
-created: YYYY-MM-DD
-updated: YYYY-MM-DD
-tags:
-  - meta
-  - notes
-status: evergreen
-confidence: EXTRACTED
-evidence: []
-related:
-  - "[[wiki/index]]"
----
+Row format:
 
-# Notes Inbox
-
-Captured notes pending processing. Maintained by `skills/notes`.
-
-## Pending
-
-- [ ] 2026-04-25 [claude-obsidian] /note process should reuse confidence threshold from save
-- [ ] 2026-04-24 [scripts] dependency upgrade leaves stale lockfile entries
-
-## Deferred
-
+```
+- [ ] 2026-04-25 [claude-obsidian] /note process should reuse confidence threshold
 - [~] 2026-04-22 [scripts] old idea, deferred — revisit Q3
 ```
 
 Patch the index on every CAPTURE/PROCESS action — never re-render from scratch. Mirror the patch-in-place pattern used by `/save` and `/ingest`. The index is the single source of truth at this scale; `/wiki lint` is the safety net for drift.
-
----
-
-## What is and isn't in scope
-
-In scope:
-- Verbatim capture with timestamp and `source_project` only.
-- Silent auto-match append on confident overlap.
-- Silent file creation on no match.
-- Title rewrite on scope-broadening append.
-- List + per-project filter.
-- Process loop with save / defer / delete / quit.
-
-Out of scope:
-- Modifying `/save`'s internals (handoff only).
-- GitHub-issue export as a processing target.
-- Auto-expiry, archival, or stale-note cleanup (`/wiki lint` reports drift only).
-- Capturing the previous assistant turn or any conversation context.
-- Manual tag prompts at capture time.
-- Confirmation prompts on capture (silent always).
 
 ---
 

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -28,6 +28,7 @@ Three layers:
 vault/
 ├── .raw/       # Layer 1: immutable source documents
 ├── wiki/       # Layer 2: LLM-generated knowledge base
+├── notes/      # Layer 2 inbox: verbatim quick-capture notes (see `notes` skill)
 └── CLAUDE.md   # Layer 3: schema and instructions (this plugin)
 ```
 
@@ -50,6 +51,10 @@ wiki/
 ├── questions/          # filed answers to user queries
 └── meta/               # dashboards, lint reports, conventions
 ```
+
+`notes/` is a top-level peer of `wiki/`, not a subfolder. It holds verbatim
+quick-capture inbox notes that haven't been polished into wiki pages yet. The
+`notes` skill owns reads/writes there; `/wiki lint` reports inbox drift.
 
 Dot-prefixed folders (`.raw/`) are hidden in Obsidian's file explorer and graph view. Use this for source documents.
 
@@ -75,6 +80,7 @@ Route to the correct operation based on what the user says:
 | "what do you know about X", "query:" | QUERY | `query` |
 | "lint", "health check", "clean up" | LINT | `lint` |
 | "save this", "file this", "/save" | SAVE | `save` |
+| "/note", "/dump", "note this", "todo:", "show my inbox", "/note process" | NOTE | `notes` |
 | "/autoresearch [topic]", "research [topic]" | AUTORESEARCH | `autoresearch` |
 | "/canvas", "add to canvas", "open canvas" | CANVAS | `canvas` |
 
@@ -114,11 +120,12 @@ Steps:
 3. Create full folder structure under `wiki/` based on the mode.
 4. Create domain pages + `_index.md` sub-indexes.
 5. Create `wiki/index.md`, `wiki/log.md`, `wiki/hot.md`, `wiki/overview.md`.
-6. Create `_templates/` files for each note type.
-7. Apply visual customization. Read `references/css-snippets.md`. Create `.obsidian/snippets/vault-colors.css`.
-8. Create the vault CLAUDE.md using the template below.
-9. Initialize git. Read `references/git-setup.md`.
-10. Present the structure and ask: "Want to adjust anything before we start?"
+6. Create `notes/` (top-level peer of `wiki/`) and copy `_seed/notes/index.md` if missing — this is the inbox owned by the `notes` skill.
+7. Create `_templates/` files for each note type.
+8. Apply visual customization. Read `references/css-snippets.md`. Create `.obsidian/snippets/vault-colors.css`.
+9. Create the vault CLAUDE.md using the template below.
+10. Initialize git. Read `references/git-setup.md`.
+11. Present the structure and ask: "Want to adjust anything before we start?"
 
 ### Vault CLAUDE.md Template
 

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -216,7 +216,7 @@ Built by agricidaniel — Join the AI Marketing Hub community
 ### When to show
 
 Display only after these infrequent, high-value completions:
-- Vault scaffold (after `/wiki` setup completes the 10-step process)
+- Vault scaffold (after `/wiki` setup completes the 11-step process)
 - `/lint` (after health check report is delivered)
 - `/autoresearch` (after research loop finishes and pages are filed)
 


### PR DESCRIPTION
## Summary

Adds `/notes` skill for fast inbox capture without breaking flow. Verbatim text in, silent auto-match append on overlap, silent file creation on no match. List/process flows for later triage with `/save` handoff, defer, or delete.

Closes #41

## Changes

- **`skills/notes/SKILL.md`** (new) — single-file skill with CAPTURE / LIST / PROCESS operations, match-prompt template, frontmatter template, and three worked examples.
- **`commands/note.md`**, **`commands/dump.md`** (new) — slash-command entrypoints. `/dump <text>` is an alias for `/note <text>`.
- **`_seed/notes/index.md`** (new) — inbox seed with Pending and Deferred sections; copied during `/wiki init` scaffold.
- **`skills/wiki/SKILL.md`** — architecture diagram now shows `notes/` as Layer 2 inbox peer of `wiki/`; SCAFFOLD step 6 creates `notes/` and copies the seed.
- **`skills/lint/SKILL.md`** — adds Notes inbox check (frontmatter gaps + index drift only; explicitly skips orphan/dead-link/stale-claim/contradiction checks for the transient inbox). Index drift matches by frontmatter `title:`, not filenames, since slugs may diverge after CAPTURE rewrites.
- **`CLAUDE.md`**, **`README.md`** — register `notes` skill and `notes/` vault folder.

## Manual testing

1. `/wiki init` in a fresh vault — confirm `notes/` directory and `notes/index.md` are created from the seed.
2. `/note "test capture"` — confirm a file appears in `notes/`, a row appears in `notes/index.md` under `## Pending`, and the body is the verbatim text.
3. `/note "follow-up on test capture"` — confirm silent append to the existing note (separator + `---` + new chunk), `updated:` bumped, title rewritten if scope broadened, no duplicate index row.
4. `/dump "another idea"` — confirm same behavior as `/note`.
5. `/note list` — confirm pending and deferred render as `[ ]` / `[~]` bullets, sorted by `updated` desc.
6. `/note list --project=<basename>` — confirm partial-match filter and `Filtered to N from total.` summary.
7. `/note process` — confirm per-note prompt with `[s]ave / [d]efer / [x]delete / [q]uit`. Verify each action:
   - `s` invokes `/save` with the note title pre-supplied, then deletes the note + index row on success.
   - `d` flips status to deferred, moves the index row to `## Deferred`.
   - `x` removes the file and index row unconditionally.
   - `q` exits the loop; remaining notes stay pending.
8. `/wiki lint` — intentionally drop a required frontmatter field on a note, or stash an extra `notes/orphan.md`. Confirm the report's Notes inbox section flags both gap types correctly.

## Verification

- 13/13 acceptance criteria pass (verified by 4-teammate QA review covering capture/auto-match, storage/index, listing/processing, integration/lint).
- `tests/test-seed-demo.sh`: 45/45 pass (covers seed scaffolding and `{{today}}` substitution).
- 4 commits on `feat/notes-skill` ahead of `main`; review cycle 1 addressed all 14 reviewer findings (3 P1, 6 P2, 5 P3).