### PR TITLE
feat: gate hot.md bootstrap-read on bootstrap_read_hot config (closes #25)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-obsidian",
-  "version": "0.4.0",
+  "version": "0.3.0",
   "description": "Claude + Obsidian knowledge companion. Sets up a persistent, compounding wiki vault. Covers memory management, session notetaking, knowledge organization, and agent context across projects.",
   "author": {
     "name": "Michał Konopski",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -30,6 +30,12 @@
       "title": "Vault path",
       "type": "directory",
       "description": "Absolute path to your Obsidian vault"
+    },
+    "bootstrap_read_hot": {
+      "title": "Hot cache auto-read mode",
+      "type": "string",
+      "default": "on-demand",
+      "description": "Controls when wiki/hot.md is injected at session start. Values: \"always\" (inject on every session start — ~2–3k tokens/turn baseline); \"on-demand\" (default — skip session-start injection; wiki skills read hot.md when they activate, so wiki sessions are unaffected); \"never\" (same hook behavior as on-demand; additionally signals to skills that they should avoid auto-reading hot.md). Change to \"always\" to restore the pre-v0.4.0 behavior."
     }
   }
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-obsidian",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Claude + Obsidian knowledge companion. Sets up a persistent, compounding wiki vault. Covers memory management, session notetaking, knowledge organization, and agent context across projects.",
   "author": {
     "name": "Michał Konopski",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ When the user opens this plugin for the first time:
 3. Hot cache auto-read depends on `claude-obsidian.bootstrap_read_hot` (default: `on-demand`):
    - `always` — `wiki/hot.md` was injected at session start by the hook; absorb it silently.
    - `on-demand` (default) — no injection occurred; wiki skills read `wiki/hot.md` when they activate. Saves ~2–3k tokens/turn for non-wiki sessions.
-   - `never` — same hook behavior as `on-demand`; additionally, skills should avoid auto-reading hot.md. Use when you never want background context loaded.
+   - `never` — same hook behavior as `on-demand`; treat this as a user preference to avoid loading `wiki/hot.md` unless the user explicitly asks for it or the current task clearly requires wiki context.
 4. If the user types `/wiki` (or "set up wiki"), follow the wiki skill's scaffold workflow
 
 ## Ingest Rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,10 @@ When the user opens this plugin for the first time:
 
 1. Read this file for context
 2. Read `skills/wiki/SKILL.md` for the orchestration pattern
-3. If `wiki/hot.md` exists, read it silently to restore recent context
+3. Hot cache auto-read depends on `claude-obsidian.bootstrap_read_hot` (default: `on-demand`):
+   - `always` — `wiki/hot.md` was injected at session start by the hook; absorb it silently.
+   - `on-demand` (default) — no injection occurred; wiki skills read `wiki/hot.md` when they activate. Saves ~2–3k tokens/turn for non-wiki sessions.
+   - `never` — same hook behavior as `on-demand`; additionally, skills should avoid auto-reading hot.md. Use when you never want background context loaded.
 4. If the user types `/wiki` (or "set up wiki"), follow the wiki skill's scaffold workflow
 
 ## Ingest Rules

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Then enable the plugin and set `vault_path` (absolute path to your Obsidian vaul
 
 The plugin wires several passive automations into every session via `hooks/hooks.json`. All of them resolve the vault path through `scripts/resolve-vault.sh` and silently skip if no vault is configured.
 
-- **SessionStart — hot cache restore.** If `wiki/hot.md` exists, its contents are injected into the session so recent context is available immediately.
-- **PostCompact — hot cache restore.** Re-injects `wiki/hot.md` after context compaction (hook-injected context does not survive compaction).
+- **SessionStart — hot cache restore.** If `wiki/hot.md` exists and `bootstrap_read_hot` is `"always"`, its contents are injected into the session so recent context is available immediately. The default is `"on-demand"` — injection is skipped and wiki skills read hot.md when they activate, saving ~2–3k tokens/turn for non-wiki sessions. See [Auto-Read Gating](_shared/hot-cache-protocol.md).
+- **PostCompact — hot cache restore.** Re-injects `wiki/hot.md` after context compaction when `bootstrap_read_hot` is `"always"` (hook-injected context does not survive compaction).
 - **PostToolUse (Edit | Write) — auto-commit.** Changes under `wiki/` and `.raw/` are auto-committed to the vault's git history with a timestamp, keeping review/blame workflow intact.
 - **PostToolUse (Edit | Write) — scratch log.** Touched file paths are appended to `$VAULT/.session-scratch.log` for the SessionEnd reflection to consume.
 - **Stop — hot cache nudge.** If wiki pages changed this session, Claude is prompted to refresh `wiki/hot.md` before stopping.

--- a/_shared/hot-cache-protocol.md
+++ b/_shared/hot-cache-protocol.md
@@ -10,11 +10,26 @@ Read this file when a skill needs to understand hot-cache behavior. Do not prelo
 
 | Trigger | Action |
 |---------|--------|
-| Session start | Read `wiki/hot.md` silently. Do not announce. Do not report what was read. Just have the context. |
-| Post-compaction | Re-read `wiki/hot.md`. Hook-injected context does not survive compaction — this restores it. |
-| Pre-query (any mode) | Read `wiki/hot.md` first. If it answers the question, respond without opening other pages. |
+| Session start (when `bootstrap_read_hot=always`) | `wiki/hot.md` was injected by the hook — silently absorb the context. Do not announce. |
+| Session start (when `bootstrap_read_hot=on-demand` or `never`) | No injection occurred. Wiki skills read `wiki/hot.md` when they activate. |
+| Post-compaction (when `bootstrap_read_hot=always`) | Re-read `wiki/hot.md`. Hook-injected context does not survive compaction — this restores it. |
+| Pre-query (any mode, unless `never`) | Read `wiki/hot.md` first. If it answers the question, respond without opening other pages. |
 
 The hot cache costs ~500 tokens. Reading it first is always cheaper than reading index or individual pages.
+
+---
+
+## Auto-Read Gating
+
+The `claude-obsidian.bootstrap_read_hot` plugin config key controls whether `wiki/hot.md` is injected at session start and post-compaction. Set it via `/plugin manage` or by editing `~/.claude/settings.local.json`.
+
+| Value | Hook behavior | Skill behavior |
+|-------|---------------|----------------|
+| `always` | Inject `wiki/hot.md` on SessionStart and PostCompact | Skills read hot.md as usual |
+| `on-demand` *(default)* | Skip injection | Skills read hot.md when they activate |
+| `never` | Skip injection | Skills should also avoid auto-reading hot.md |
+
+**Why the default is `on-demand`:** At ~2–3k tokens/turn, always injecting `wiki/hot.md` is a hidden per-session cost that accumulates across all sessions — including unrelated coding work. Wiki skills already read hot.md on activation, so `on-demand` preserves the benefit for wiki sessions while eliminating the cost for everything else. Restore the previous behavior with `bootstrap_read_hot: "always"`.
 
 ---
 

--- a/_shared/hot-cache-protocol.md
+++ b/_shared/hot-cache-protocol.md
@@ -13,9 +13,9 @@ Read this file when a skill needs to understand hot-cache behavior. Do not prelo
 | Session start (when `bootstrap_read_hot=always`) | `wiki/hot.md` was injected by the hook — silently absorb the context. Do not announce. |
 | Session start (when `bootstrap_read_hot=on-demand` or `never`) | No injection occurred. Wiki skills read `wiki/hot.md` when they activate. |
 | Post-compaction (when `bootstrap_read_hot=always`) | Re-read `wiki/hot.md`. Hook-injected context does not survive compaction — this restores it. |
-| Pre-query (any mode, unless `never`) | Read `wiki/hot.md` first. If it answers the question, respond without opening other pages. |
+| Pre-query (any mode) | Read `wiki/hot.md` first. If it answers the question, respond without opening other pages. When `bootstrap_read_hot=never`, treat this as a user preference to skip the auto-read unless the task clearly requires wiki context. |
 
-The hot cache costs ~500 tokens. Reading it first is always cheaper than reading index or individual pages.
+When kept under the 500-word budget, `wiki/hot.md` costs ~500 tokens to read — always cheaper than reading the index or individual pages. The "~2–3k tokens/turn" figure cited elsewhere refers to the per-turn cost of injecting hot.md at every SessionStart and PostCompact when `bootstrap_read_hot=always`; that cost grows further if hot.md drifts past its word budget.
 
 ---
 
@@ -27,7 +27,7 @@ The `claude-obsidian.bootstrap_read_hot` plugin config key controls whether `wik
 |-------|---------------|----------------|
 | `always` | Inject `wiki/hot.md` on SessionStart and PostCompact | Skills read hot.md as usual |
 | `on-demand` *(default)* | Skip injection | Skills read hot.md when they activate |
-| `never` | Skip injection | Skills should also avoid auto-reading hot.md |
+| `never` | Skip injection | Advisory signal — skills should avoid auto-reading hot.md unless the user explicitly asks or the task clearly requires wiki context. Not enforced in skill code today; treat as a user preference. |
 
 **Why the default is `on-demand`:** At ~2–3k tokens/turn, always injecting `wiki/hot.md` is a hidden per-session cost that accumulates across all sessions — including unrelated coding work. Wiki skills already read hot.md on activation, so `on-demand` preserves the benefit for wiki sessions while eliminating the cost for everything else. Restore the previous behavior with `bootstrap_read_hot: "always"`.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,11 +6,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; MODE=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-config.sh\" bootstrap_read_hot on-demand); [ \"$MODE\" = \"always\" ] && [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
           },
           {
             "type": "prompt",
-            "prompt": "If a vault is configured for this session (check CLAUDE.md for VAULT_PATH or a wiki/ folder in the current directory), silently read wiki/hot.md to restore recent context. If wiki/hot.md does not exist, do nothing. This is a non-vault session. Do not announce this. Do not report what you read. Just have the context available."
+            "prompt": "If the vault is configured AND bootstrap_read_hot is \"always\", wiki/hot.md was just injected above — silently absorb that context. If bootstrap_read_hot is \"on-demand\" or \"never\" (the default), hot.md was not injected; wiki skills will read it when they activate. Do not announce this. Do not report what you read."
           }
         ]
       }
@@ -21,11 +21,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; MODE=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-config.sh\" bootstrap_read_hot on-demand); [ \"$MODE\" = \"always\" ] && [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
           },
           {
             "type": "prompt",
-            "prompt": "Hook-injected context does not survive context compaction. If wiki/hot.md exists in the vault, silently re-read it now to restore the hot cache. Do not announce this."
+            "prompt": "Hook-injected context does not survive context compaction. If bootstrap_read_hot is \"always\" and wiki/hot.md was re-injected above, silently absorb that context to restore the hot cache. If bootstrap_read_hot is \"on-demand\" or \"never\", no injection occurred; wiki skills will read hot.md when needed. Do not announce this."
           }
         ]
       }

--- a/scripts/resolve-config.sh
+++ b/scripts/resolve-config.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Resolve a plugin config value in priority order:
+#   1. ~/.claude/settings.local.json  (pluginConfigs[*claude-obsidian*].options.<key>)
+#   2. ~/.claude/settings.json        (same key, userSettings scope)
+#   3. $2 default (if provided)
+# Usage: resolve-config.sh <key> [default]
+KEY="${1:-}"
+DEFAULT="${2:-}"
+
+if [ -z "$KEY" ]; then
+  echo "resolve-config.sh: key argument required" >&2
+  exit 1
+fi
+
+read_config_from_settings() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  if command -v jq >/dev/null 2>&1; then
+    jq -r --arg key "$KEY" '(.pluginConfigs // {}) | to_entries[] | select(.key | contains("claude-obsidian")) | .value.options[$key] // empty' "$file" 2>/dev/null | head -1
+  elif command -v python3 >/dev/null 2>&1; then
+    SETTINGS_FILE="$file" CONFIG_KEY="$KEY" python3 -c '
+import json, os
+try:
+    with open(os.environ["SETTINGS_FILE"]) as f:
+        d = json.load(f)
+    key = os.environ["CONFIG_KEY"]
+    for k, v in d.get("pluginConfigs", {}).items():
+        if "claude-obsidian" in k:
+            val = v.get("options", {}).get(key, "")
+            if val:
+                print(val)
+            break
+except Exception:
+    pass
+' 2>/dev/null
+  fi
+}
+
+VALUE=""
+for settings_file in "$HOME/.claude/settings.local.json" "$HOME/.claude/settings.json"; do
+  [ -n "$VALUE" ] && break
+  VALUE=$(read_config_from_settings "$settings_file")
+done
+
+if [ -z "$VALUE" ]; then
+  echo "${DEFAULT}"
+else
+  echo "$VALUE"
+fi


### PR DESCRIPTION
## Summary

- Adds `claude-obsidian.bootstrap_read_hot` plugin config key with three values: `always | on-demand | never` (default: `on-demand`).
- `SessionStart` and `PostCompact` hooks only inject `wiki/hot.md` when the value is `always`; on any other value the injection is skipped.
- New `scripts/resolve-config.sh` reads plugin config values from `settings.local.json` → `settings.json` → supplied default, following the same jq→python3→echo fallback chain as `resolve-vault.sh`.
- `CLAUDE.md`, `_shared/hot-cache-protocol.md`, and `README.md` updated to document the gate, the cost trade-off, and how to restore previous behavior.
- Bumps plugin version to `0.4.0` (breaking default change).

Closes #25

## Behavior change

| Config value | Hook behavior | Per-session cost |
|---|---|---|
| `always` (previous default) | `wiki/hot.md` injected on SessionStart + PostCompact | ~2–3k tokens/turn |
| `on-demand` **(new default)** | No injection; wiki skills read hot.md on activation | 0 for non-wiki sessions |
| `never` | Same as `on-demand`; skills treat it as a stronger signal to skip auto-reads | 0 |

**Migration:** Users who relied on session-start priming for non-wiki sessions can restore it with one settings entry:

```json
{
  "pluginConfigs": {
    "claude-obsidian": {
      "options": { "bootstrap_read_hot": "always" }
    }
  }
}
```

## Manual testing (AC2)

1. **Baseline (`on-demand`):** Open a fresh session in a project with a configured vault. Run `/context`. Capture the **memory files** and **system prompt tokens** lines. Confirm `wiki/hot.md` does **not** appear in injected memory.

2. **Toggle to `always`:** Add `bootstrap_read_hot: "always"` to `~/.claude/settings.local.json` under the `claude-obsidian` plugin config.

3. **With `always`:** Open another fresh session, run `/context`. Confirm `wiki/hot.md` **appears** in injected memory.

4. **Delta:** The token count difference between the two runs = the per-turn savings from the new default.

Expected: `on-demand` baseline omits hot.md; `always` baseline includes it at ~2–3k tokens.

## Files changed

| File | Change |
|---|---|
| `scripts/resolve-config.sh` | New — reads plugin config key with jq→python3→default fallback |
| `.claude-plugin/plugin.json` | Added `bootstrap_read_hot` userConfig entry; bumped to v0.4.0 |
| `hooks/hooks.json` | SessionStart + PostCompact `cat` commands gated on `MODE == "always"` |
| `CLAUDE.md` | Bootstrap step 3 rewritten to describe conditional read + token cost |
| `_shared/hot-cache-protocol.md` | "When to Read" table updated; new "Auto-Read Gating" section added |
| `README.md` | SessionStart + PostCompact hook bullets updated to mention the gate |