### PR TITLE
fix: detach session-reflection hook to avoid SessionEnd cancellation

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -62,7 +62,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/session-reflection.sh\""
+            "command": "nohup \"${CLAUDE_PLUGIN_ROOT}/hooks/session-reflection.sh\" >/dev/null 2>&1 < /dev/null & disown"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Changes `hooks/hooks.json` to run `session-reflection.sh` via `nohup ... & disown` instead of synchronously.

Closes #55

## Root cause

The SessionEnd hook was spawning a full `claude -p` subprocess synchronously. That subprocess takes 10–30s (plugin load + API call), which exceeds Claude Code's hard exit deadline. The parent process kills the hook and reports `Hook cancelled`.

## What changed

Single-line change in `hooks/hooks.json`: the SessionEnd command is now fire-and-forget. The reflection script itself is unchanged — it already handles all early-exit cases (no vault, empty scratch, no CLI) before touching the API.

## Manual testing

1. Configure the plugin with a valid vault path.
2. Run a session that writes or edits files (so `.session-scratch.log` gets populated).
3. Exit the session (`/exit`).
4. **Expected before fix:** `SessionEnd hook … failed: Hook cancelled` appears.
5. **Expected after fix:** No error. Within ~30s, `daily/YYYY-MM-DD.md` in the vault is appended with reflection bullets.

To verify the no-op path: exit a session without touching any files → no daily note entry, no error.