### PR TITLE
fix: drop disown from SessionEnd hook for dash compatibility

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -62,7 +62,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "nohup \"${CLAUDE_PLUGIN_ROOT}/hooks/session-reflection.sh\" >/dev/null 2>&1 < /dev/null & disown"
+            "command": "nohup \"${CLAUDE_PLUGIN_ROOT}/hooks/session-reflection.sh\" >/dev/null 2>&1 < /dev/null &"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Claude Code runs hooks via `/bin/sh`. On Debian/Ubuntu that is dash, which has no `disown` builtin, so the SessionEnd hook fails with `/bin/sh: 1: disown: not found`.
- `nohup ... &` already detaches the process and shields it from SIGHUP, making `disown` redundant. Dropping it makes the hook portable across dash, bash, and zsh.
- Follow-up to #56, which introduced the `nohup ... & disown` form.

## Test plan
- [ ] End a session in a fresh shell on a system where `/bin/sh` is dash and confirm no SessionEnd hook error appears.
- [ ] Confirm `session-reflection.sh` still runs to completion in the background after the parent session exits.