### PR TITLE
fix: remove prompt-type hooks that fail with ToolUseContext error

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -10,11 +10,7 @@
           },
           {
             "type": "command",
-            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; MODE=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-config.sh\" bootstrap_read_hot on-demand); [ \"$MODE\" = \"always\" ] && [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
-          },
-          {
-            "type": "prompt",
-            "prompt": "If the vault is configured AND bootstrap_read_hot is \"always\", wiki/hot.md was just injected above — silently absorb that context. If bootstrap_read_hot is \"on-demand\" or \"never\" (the default), hot.md was not injected; wiki skills will read it when they activate. Do not announce this. Do not report what you read."
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; MODE=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-config.sh\" bootstrap_read_hot on-demand); if [ \"$MODE\" = \"always\" ] && [ -f \"$VAULT/wiki/hot.md\" ]; then cat \"$VAULT/wiki/hot.md\"; printf '\\n\\n[claude-obsidian] wiki/hot.md was injected above (bootstrap_read_hot=always). Silently absorb this context; do not announce it.\\n'; fi; exit 0"
           }
         ]
       }
@@ -25,11 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; MODE=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-config.sh\" bootstrap_read_hot on-demand); [ \"$MODE\" = \"always\" ] && [ -f \"$VAULT/wiki/hot.md\" ] && cat \"$VAULT/wiki/hot.md\" || true"
-          },
-          {
-            "type": "prompt",
-            "prompt": "Hook-injected context does not survive context compaction. If bootstrap_read_hot is \"always\" and wiki/hot.md was re-injected above, silently absorb that context to restore the hot cache. If bootstrap_read_hot is \"on-demand\" or \"never\", no injection occurred; wiki skills will read hot.md when needed. Do not announce this."
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; MODE=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-config.sh\" bootstrap_read_hot on-demand); if [ \"$MODE\" = \"always\" ] && [ -f \"$VAULT/wiki/hot.md\" ]; then cat \"$VAULT/wiki/hot.md\"; printf '\\n\\n[claude-obsidian] wiki/hot.md was re-injected above after compaction (bootstrap_read_hot=always). Silently absorb this context to restore the hot cache; do not announce it.\\n'; fi; exit 0"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- `SessionStart` and `PostCompact` declared `type: "prompt"` hooks that Claude Code rejects with `ToolUseContext is required for prompt hooks. This is a bug.` — a noisy banner at the top of every new session and after every compaction.
- The two prompt hooks only contained absorb-silently guidance for the hot.md content emitted by the preceding command hook. I folded that guidance into the command hook's stdout, conditional on actual injection.

## Why this works

Prompt-type hooks appear to require a tool-use context (the runtime error suggests they're only valid for tool-event hooks like PreToolUse/PostToolUse). Session-level events don't have one, so the harness errors out before the hook runs.

The fix keeps behavior identical:
- `bootstrap_read_hot != "always"` → nothing emitted (same as before).
- `bootstrap_read_hot = "always"` → hot.md content + a one-line absorb-silently note, all via the command hook's stdout. Stdout from a SessionStart command hook is added as additional context — the model sees it, same as the prompt-type hook would have provided.

## Test plan

- [x] `hooks/hooks.json` is valid JSON
- [x] No more prompt-type hooks in session-event sections
- [ ] Verify in a fresh Claude Code session that the `ToolUseContext` banner no longer appears
- [ ] With `bootstrap_read_hot=always`, verify hot.md still gets injected at session start