### PR TITLE
docs(skills): drop wrapper-usage repetition from query and save

### DIFF
--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -10,8 +10,6 @@ The wiki has already done the synthesis work. Read strategically, answer precise
 
 ## Vault Reads
 
-Vault reads use the Obsidian CLI (see CLAUDE.md → Vault I/O for the global rule). `Read` is reserved for resources outside the vault.
-
 | Op | Invocation |
 |---|---|
 | Hot cache | `obsidian read path=wiki/hot.md` |
@@ -36,8 +34,8 @@ Three depths. Choose based on the question complexity.
 
 Use when the answer is likely in the hot cache or index summary.
 
-1. Read `wiki/hot.md` via `obsidian read path=wiki/hot.md`. If it answers the question, respond immediately.
-2. If not, read `wiki/index.md` via `obsidian read path=wiki/index.md`. Scan descriptions for the answer.
+1. Read `wiki/hot.md`. If it answers the question, respond immediately.
+2. If not, read `wiki/index.md`. Scan descriptions for the answer.
 3. If found in index summary, respond and do not open any pages.
 4. If not found, say "Not in quick cache. Run as standard query?"
 
@@ -49,7 +47,7 @@ Do not open individual wiki pages in quick mode.
 
 1. **Read** `wiki/hot.md` first. It may already have the answer or directly relevant context.
 2. **Read** `wiki/index.md` to find the most relevant pages (scan for titles and descriptions).
-3. **Read** those pages via `obsidian read path=wiki/<category>/<page>.md`. Follow wikilinks to depth-2 for key entities. No deeper.
+3. **Read** those pages. Follow wikilinks to depth-2 for key entities. No deeper.
 4. **Synthesize** the answer in chat. Cite sources with wikilinks: `(Source: [[Page Name]])`.
 5. **Offer to file** the answer: "This analysis seems worth keeping. Should I save it as `wiki/questions/answer-name.md`?"
 6. If the question reveals a **gap**: say "I don't have enough on X. Want to find a source?"
@@ -60,9 +58,9 @@ Do not open individual wiki pages in quick mode.
 
 Use for synthesis questions, comparisons, or "tell me everything about X."
 
-1. Read `wiki/hot.md` and `wiki/index.md` via the wrapper.
+1. Read `wiki/hot.md` and `wiki/index.md`.
 2. Identify all relevant sections (concepts, entities, sources, comparisons).
-3. Read every relevant page via the wrapper. No skipping.
+3. Read every relevant page. No skipping.
 4. If wiki coverage is thin, offer to supplement with web search.
 5. Synthesize a comprehensive answer with full citations.
 6. Always file the result back as a wiki page. Deep answers are too valuable to lose.

--- a/skills/save/SKILL.md
+++ b/skills/save/SKILL.md
@@ -18,8 +18,6 @@ The wiki compounds. Save often.
 
 ## Vault Writes
 
-Vault reads and writes use the Obsidian CLI (see CLAUDE.md → Vault I/O for the global rule). The skill no longer needs `Write` or `Edit`; `Read` is reserved for resources outside the vault.
-
 | Op | Invocation |
 |---|---|
 | Read template / existing page | `obsidian read path=<path>` |
@@ -28,7 +26,7 @@ Vault reads and writes use the Obsidian CLI (see CLAUDE.md → Vault I/O for the
 | Prepend to master index | `obsidian prepend file=wiki/index.md content="<entry>"` |
 | Rewrite hot cache | `obsidian create path=wiki/hot.md content="<body>" overwrite` |
 
-Multiline content uses the CLI's `\n` escape (round-trip verified empirically — see `tests/spike-results/rmw-mutate-diff.out`). If a future spike reveals the round-trip is broken, fall back to `obsidian create source=/tmp/staging.md path=wiki/...`.
+Multiline content uses `\n` escapes inside `content="..."`.
 
 ---
 
@@ -73,7 +71,7 @@ If the user specifies a type, use that. If not, pick the best fit based on the c
      file=wiki/log.md \
      content="## [YYYY-MM-DD] save | Note Title\n- Type: [note type]\n- Location: wiki/[folder]/Note Title.md\n- From: conversation on [brief topic description]\n\n"
    ```
-9. **Rewrite** `wiki/hot.md` via `obsidian create path=wiki/hot.md content="..." overwrite`. Follow the format in `${CLAUDE_PLUGIN_ROOT}/_shared/hot-cache-protocol.md`. Multiline content uses `\n` escapes.
+9. **Rewrite** `wiki/hot.md` (use the `overwrite` flag). Follow the format in `${CLAUDE_PLUGIN_ROOT}/_shared/hot-cache-protocol.md`.
 10. **Confirm**: "Saved as [[Note Title]] in wiki/[folder]/."
 
 ---


### PR DESCRIPTION
Follow-up to #54.

## Why

The wrapper-usage contract is documented in three places that mostly say the same thing:

1. **`CLAUDE.md` → Vault I/O** — authoritative; loaded into every session. States the rule (vault I/O via Obsidian CLI), the rewrite hook, exit-code normalization, and that \`Read\` is for outside-vault paths.
2. **\`skills/query/SKILL.md\`** — repeats the preamble (\"Vault reads use the Obsidian CLI (see CLAUDE.md → Vault I/O...). \`Read\` is reserved for...\") + adds inline \"via \`obsidian read path=...\`\" reminders inside numbered steps.
3. **\`skills/save/SKILL.md\`** — same preamble; plus a multiline-roundtrip paragraph asserting a contract that's already documented in \`scripts/obsidian-cli.sh\`'s header.

Given the PreToolUse rewrite hook (also from #54) transparently routes raw \`obsidian <verb>\` calls through the wrapper, the skills don't need to explain *why* the wrapper exists — they just need to call \`obsidian <verb>\`.

## Changes

- Drop the \"Vault reads use the Obsidian CLI...\" preamble from both skills.
- Drop inline \"via the wrapper\" / \"via \`obsidian read path=...\`\" suffixes inside numbered steps where the verb table immediately above already documents the invocation.
- Collapse the multiline-roundtrip paragraph in \`save\` into a one-liner — the empirical contract lives in \`scripts/obsidian-cli.sh\`'s header comment and \`tests/spike-results/\`, not in skill prose.

Verb tables stay — they're skill-specific and load-bearing.

\`CLAUDE.md\` unchanged.

## Diff size

\`\`\`
skills/query/SKILL.md | 12 +++++-------
skills/save/SKILL.md  |  6 ++----
2 files changed, 7 insertions(+), 11 deletions(-)
\`\`\`

## Test plan

- [x] \`bash tests/cli-smoke.sh\` — same 19 pass / 2 fail as on \`main\` (the 2 failures are pre-existing and unrelated to docs)
- [ ] Spot-check that \`/query\` and \`/save\` still behave correctly end-to-end against an active vault