### PR TITLE
feat(notes): title-driven filename slug for /note (closes #61)

### DIFF
--- a/scripts/slug.sh
+++ b/scripts/slug.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# slug.sh — Vault filename slug generator.
+#
+# Generates a 40-char-max slug from a title, with a body-derived fallback
+# when the title slugifies to empty. Used by /note (sub-issue #61) and the
+# capture pipeline shared by /daily and /braindump (sub-issue #62).
+#
+# Usage:
+#   slug.sh "<title>" [<fallback-body>]
+#
+# Output:
+#   The slug to stdout (no date prefix, no .md extension, no collision suffix —
+#   callers assemble the final filename and resolve same-day collisions).
+#
+# Exit codes:
+#   0 — slug emitted
+#   1 — title and fallback both slugify to empty
+#   2 — argument error
+#
+# Slug rules (matches AC #1–#3, #5, #8 of issue #61):
+#   1. Lowercase.
+#   2. Non-alphanumerics → "-"; runs of "-" collapsed; leading/trailing "-" trimmed.
+#   3. ≤ 40 chars: use whole.
+#   4. > 40 chars: truncate at the last "-" before char 40 (word boundary).
+#      If no "-" exists before char 40 (first word ≥ 40 chars), hard-truncate at 40.
+#   5. Empty/whitespace after trimming AND a non-empty <fallback-body> given:
+#      slugify the body, then hard-truncate to 40 (no word-boundary smarts —
+#      bodies are user verbatim and may have no useful break points).
+
+set -euo pipefail
+
+slugify() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//'
+}
+
+# truncate_at_word_boundary <slug> <max>
+# Returns slug unchanged if ≤ max. Otherwise slices to max chars and strips
+# any trailing partial word: ${head%-*} drops the shortest "-…" suffix, which
+# either trims a trailing "-" or removes a half-cut last word. If no "-" is
+# present in the head, the result equals the head — i.e. a hard truncation.
+truncate_at_word_boundary() {
+  local s="$1" max="$2"
+  if [ "${#s}" -le "$max" ]; then
+    printf '%s' "$s"
+    return
+  fi
+  local head="${s:0:$max}"
+  printf '%s' "${head%-*}"
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "usage: slug.sh \"<title>\" [<fallback-body>]" >&2
+  exit 2
+fi
+
+title="$1"
+fallback="${2:-}"
+
+slug="$(slugify "$title")"
+if [ -n "$slug" ]; then
+  truncate_at_word_boundary "$slug" 40
+  exit 0
+fi
+
+if [ -n "$fallback" ]; then
+  body_slug="$(slugify "$fallback")"
+  if [ -n "$body_slug" ]; then
+    printf '%s' "${body_slug:0:40}"
+    exit 0
+  fi
+fi
+
+echo "slug: title and fallback both slugify to empty" >&2
+exit 1

--- a/skills/notes/SKILL.md
+++ b/skills/notes/SKILL.md
@@ -63,11 +63,7 @@ Steps:
    - **Filename is never renamed.** Drift between filename slug and rewritten `title` is acceptable.
 6. **NEW path** — create a new file:
    - **Title.** Derive a one-line summary (≤80 chars) of the verbatim text, stripping leading filler ("we need to", "can we check", "I think we should") so the substance leads. If the verbatim text is itself short, substantive, and one-line, use it as the title.
-   - **Slug.** Compute via the shared script — do not slugify in-prompt:
-     ```bash
-     slug=$(bash ${CLAUDE_PLUGIN_ROOT}/scripts/slug.sh "$title" "$body")
-     ```
-     The script lowercases, replaces non-alphanumerics with `-`, collapses runs, trims, and applies word-boundary truncation at char 40 (hard-truncate when the first word is ≥ 40 chars). When the title slugifies to empty (all special chars), it falls back to a 40-char body slug. Exit 1 means both are empty — surface that as an error rather than inventing a name. The script is the source of truth for the slug rule; reuse it from `/daily` and `/braindump` once those land (epic #60).
+   - **Slug.** Compute via `bash ${CLAUDE_PLUGIN_ROOT}/scripts/slug.sh "$title" "$body"` — see that script's header for the contract. Do not slugify in-prompt. Exit 1 means both inputs slugify to empty; surface that as an error rather than inventing a name.
    - **Path:** `<vault_root>/notes/YYYY-MM-DD-<slug>.md`. If that filename already exists for today, append a counter suffix `-2`, `-3`, … incrementing. Different days never collide because the date prefix differs.
    - **Frontmatter** from the template below; body is the verbatim text. Topic and tags may be left empty (`""` and `[]`) — they're populated by the user later if needed.
 7. **Update `notes/index.md`** — patch in place, no full rewrite:

--- a/skills/notes/SKILL.md
+++ b/skills/notes/SKILL.md
@@ -62,11 +62,12 @@ Steps:
    - If the new content broadens the note's scope, **rewrite `title:`** to a phrase covering the union. Bump `updated:` to today. Frontmatter `topic:` and `tags:` may be widened as needed; never narrowed.
    - **Filename is never renamed.** Drift between filename slug and rewritten `title` is acceptable.
 6. **NEW path** — create a new file:
-   - **Title first.** Derive a one-line summary (≤80 chars) of the verbatim text, stripping leading filler ("we need to", "can we check", "I think we should") so the substance leads. If the verbatim text is itself short, substantive, and one-line, use it as the title. Trim leading/trailing whitespace before slugifying.
-   - **Slug from the title.** Lowercase, non-alphanumerics → `-`, collapse runs, trim leading/trailing `-`. Length rules:
-     - ≤ 40 chars → use whole.
-     - \> 40 chars → truncate at the **last `-` before char 40** (word-boundary). If no `-` exists before char 40 (first word ≥ 40 chars), hard-truncate at char 40.
-     - empty/whitespace after trimming (title slugifies to nothing — all special chars) → **fall back** to the body-derived 40-char slug: lowercase verbatim body, non-alphanumerics → `-`, collapse runs, trim, hard-truncate to 40 chars.
+   - **Title.** Derive a one-line summary (≤80 chars) of the verbatim text, stripping leading filler ("we need to", "can we check", "I think we should") so the substance leads. If the verbatim text is itself short, substantive, and one-line, use it as the title.
+   - **Slug.** Compute via the shared script — do not slugify in-prompt:
+     ```bash
+     slug=$(bash ${CLAUDE_PLUGIN_ROOT}/scripts/slug.sh "$title" "$body")
+     ```
+     The script lowercases, replaces non-alphanumerics with `-`, collapses runs, trims, and applies word-boundary truncation at char 40 (hard-truncate when the first word is ≥ 40 chars). When the title slugifies to empty (all special chars), it falls back to a 40-char body slug. Exit 1 means both are empty — surface that as an error rather than inventing a name. The script is the source of truth for the slug rule; reuse it from `/daily` and `/braindump` once those land (epic #60).
    - **Path:** `<vault_root>/notes/YYYY-MM-DD-<slug>.md`. If that filename already exists for today, append a counter suffix `-2`, `-3`, … incrementing. Different days never collide because the date prefix differs.
    - **Frontmatter** from the template below; body is the verbatim text. Topic and tags may be left empty (`""` and `[]`) — they're populated by the user later if needed.
 7. **Update `notes/index.md`** — patch in place, no full rewrite:

--- a/skills/notes/SKILL.md
+++ b/skills/notes/SKILL.md
@@ -62,10 +62,13 @@ Steps:
    - If the new content broadens the note's scope, **rewrite `title:`** to a phrase covering the union. Bump `updated:` to today. Frontmatter `topic:` and `tags:` may be widened as needed; never narrowed.
    - **Filename is never renamed.** Drift between filename slug and rewritten `title` is acceptable.
 6. **NEW path** — create a new file:
-   - Slug from title: lowercase, non-alphanumerics → `-`, collapse runs, trim leading/trailing `-`, truncate to 40 chars. If a file with that name exists for today, append `-2`, `-3`, etc.
-   - Path: `<vault_root>/notes/YYYY-MM-DD-<slug>.md`.
-   - Frontmatter from the template below; body is the verbatim text.
-   - For NEW captures the title is the user's text trimmed to a one-line summary (≤80 chars). If the verbatim text is itself short and one-line, use it as the title. Topic and tags may be left empty (`""` and `[]`) — they're populated by the user later if needed.
+   - **Title first.** Derive a one-line summary (≤80 chars) of the verbatim text, stripping leading filler ("we need to", "can we check", "I think we should") so the substance leads. If the verbatim text is itself short, substantive, and one-line, use it as the title. Trim leading/trailing whitespace before slugifying.
+   - **Slug from the title.** Lowercase, non-alphanumerics → `-`, collapse runs, trim leading/trailing `-`. Length rules:
+     - ≤ 40 chars → use whole.
+     - \> 40 chars → truncate at the **last `-` before char 40** (word-boundary). If no `-` exists before char 40 (first word ≥ 40 chars), hard-truncate at char 40.
+     - empty/whitespace after trimming (title slugifies to nothing — all special chars) → **fall back** to the body-derived 40-char slug: lowercase verbatim body, non-alphanumerics → `-`, collapse runs, trim, hard-truncate to 40 chars.
+   - **Path:** `<vault_root>/notes/YYYY-MM-DD-<slug>.md`. If that filename already exists for today, append a counter suffix `-2`, `-3`, … incrementing. Different days never collide because the date prefix differs.
+   - **Frontmatter** from the template below; body is the verbatim text. Topic and tags may be left empty (`""` and `[]`) — they're populated by the user later if needed.
 7. **Update `notes/index.md`** — patch in place, no full rewrite:
    - On NEW: prepend a row under `## Pending`.
    - On MATCH: find the existing row by the **pre-rewrite title** (the title the file had before this operation). Bump its date to today; if the title was rewritten, replace the title text. Never add a duplicate row.
@@ -206,6 +209,14 @@ Patch the index on every CAPTURE/PROCESS action — never re-render from scratch
 ```
 user> /note inbox count missing from /wiki status
 assistant> Captured to notes/2026-04-25-inbox-count-missing-from-wiki-status.md
+```
+
+**Capture (NEW, filler stripped from title):**
+```
+user> /note we need to check why claude-workflow is not using 'wt' for worktrees but the git cli directly
+# title summarised to "claude-workflow uses git CLI instead of wt for worktrees"
+# slug exceeds 40 chars; truncated at last `-` before char 40
+assistant> Captured to notes/2026-04-26-claude-workflow-uses-git-cli-instead.md
 ```
 
 **Capture (MATCH-append, scope unchanged):**

--- a/tests/slug-test.sh
+++ b/tests/slug-test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Tests for scripts/slug.sh.
+#
+# Pins the slug-rule acceptance criteria from issue #61. Each assertion maps
+# to a numbered AC where applicable.
+#
+# Usage:
+#   bash tests/slug-test.sh
+#
+# Exits non-zero if any assertion fails.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SLUG="$PLUGIN_ROOT/scripts/slug.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  [ok] $1"; PASS=$((PASS + 1)); }
+fail() { echo "  [FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+# assert_eq <expected> <actual> <label>
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    pass "$label"
+  else
+    fail "$label — got '$actual', expected '$expected'"
+  fi
+}
+
+# assert_exit <expected> <actual> <label>
+assert_exit() {
+  local expected="$1" actual="$2" label="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    pass "$label — exit=$actual"
+  else
+    fail "$label — exit=$actual (expected $expected)"
+  fi
+}
+
+if [ ! -x "$SLUG" ]; then
+  echo "slug-test: $SLUG missing or not executable" >&2
+  exit 2
+fi
+
+echo ""
+echo "=== slug-test — slug.sh contract ==="
+
+# AC1 — title-driven slug, simple case.
+out=$(bash "$SLUG" "Fix flaky CI runner")
+assert_eq "fix-flaky-ci-runner" "$out" "AC1: simple title slugifies"
+
+# AC2 — slug ≤ 40 chars: used whole, no truncation.
+out=$(bash "$SLUG" "Short title under forty chars")
+assert_eq "short-title-under-forty-chars" "$out" "AC2: ≤40 chars used whole"
+
+# AC3a — slug > 40 chars: word-boundary truncation at last "-" before char 40.
+# Input slug "claude-workflow-uses-git-cli-instead-of-wt-for-worktrees" (56 chars)
+# Char-40 head is "claude-workflow-uses-git-cli-instead-of-" (ends with -);
+# stripping shortest "-*" leaves "claude-workflow-uses-git-cli-instead-of" (39).
+out=$(bash "$SLUG" "claude-workflow uses git CLI instead of wt for worktrees")
+assert_eq "claude-workflow-uses-git-cli-instead-of" "$out" "AC3a: word-boundary truncation"
+[ "${#out}" -le 40 ] && pass "AC3a: result ≤ 40 chars (${#out})" \
+                    || fail "AC3a: result > 40 chars (${#out})"
+
+# AC3b — first word ≥ 40 chars, no "-" before char 40: hard-truncated at 40.
+out=$(bash "$SLUG" "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz")
+assert_eq "abcdefghijklmnopqrstuvwxyzabcdefghijklmn" "$out" "AC3b: hard-truncate when no word break"
+[ "${#out}" -eq 40 ] && pass "AC3b: result is exactly 40 chars" \
+                    || fail "AC3b: result is ${#out} chars (expected 40)"
+
+# AC5a — title slugifies to empty, body fallback used.
+out=$(bash "$SLUG" "!@#\$%^&*()" "fallback content from body")
+assert_eq "fallback-content-from-body" "$out" "AC5a: empty-title falls back to body slug"
+
+# AC5b — title and body both slugify to empty: exit 1.
+out=$(bash "$SLUG" "!@#" "***" 2>/dev/null); rc=$?
+assert_exit 1 "$rc" "AC5b: both empty → exit 1"
+
+# AC8 — leading/trailing whitespace trimmed before slugifying (no leading/trailing "-").
+out=$(bash "$SLUG" "  Foo Bar  ")
+assert_eq "foo-bar" "$out" "AC8: leading/trailing whitespace trimmed"
+
+# Collapse runs of separators.
+out=$(bash "$SLUG" "foo!!!bar???baz")
+assert_eq "foo-bar-baz" "$out" "collapse: runs of non-alphanumerics → single -"
+
+# Mixed case lowercased.
+out=$(bash "$SLUG" "Hello World")
+assert_eq "hello-world" "$out" "lowercase: mixed case → lowercase"
+
+# Argument validation: zero args → exit 2.
+out=$(bash "$SLUG" 2>/dev/null); rc=$?
+assert_exit 2 "$rc" "no args → exit 2"
+
+# Argument validation: too many args → exit 2.
+out=$(bash "$SLUG" a b c 2>/dev/null); rc=$?
+assert_exit 2 "$rc" "three args → exit 2"
+
+echo ""
+echo "=== slug-test summary ==="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- Closes #61 (sub-issue A of epic #60 — Notes v2).
- Reworks `skills/notes/SKILL.md` CAPTURE step 6 (NEW path) so the filename slug is derived from the LLM-summarised `title:` instead of the verbatim body. Titles already strip leading filler, so the slug leads with substance.
- **Extracts the slug rule into `scripts/slug.sh`** (single source of truth) — the skill body invokes the script instead of re-stating the rule in-prompt. Determinism for char-counting/word-boundary logic, plus reuse for `/daily` and `/braindump` once sub-issue B (#62) lands.
- Adds `tests/slug-test.sh` pinning the slug ACs (13 assertions, all passing).

## Why a script (scope expansion, 2026-04-27)

The first revision wrote the slug rule inline in the skill body. We expanded scope after a short discussion:

- **Determinism.** Counting chars, finding the last `-` before char 40, applying the fallback chain — exactly the kind of arithmetic-on-strings task LLMs get subtly wrong. A bash script with `tr`/`sed`/parameter-expansion is unambiguously correct.
- **Reuse for #62.** The capture-pipeline extraction for `/daily` and `/braindump` will reuse `scripts/slug.sh` directly. No duplication of the rule into `_shared/capture-pipeline.md`.
- **Testability.** `tests/slug-test.sh` pins the ACs; an in-prompt rule cannot be regression-tested.

Token impact is negligible (skill body loads once per session). The win is correctness + downstream reuse.

## Files

| Path | Purpose |
|---|---|
| `scripts/slug.sh` (new) | Slugify a title, with body-fallback, word-boundary truncation. Slug only — caller assembles the filename and handles same-day collisions. |
| `tests/slug-test.sh` (new) | 13 assertions pinning ACs 1, 2, 3a, 3b, 5a, 5b, 8 + collapse, lowercase, arg validation. |
| `skills/notes/SKILL.md` | CAPTURE step 6 (NEW path) invokes `scripts/slug.sh`; example added showing filler-stripping + word-boundary truncation. |

## Acceptance criteria coverage

| AC | Where |
|---|---|
| 1 — title-driven slug | `slug.sh` + `tests/slug-test.sh` AC1 |
| 2 — ≤ 40 chars whole | `slug.sh` + AC2 test |
| 3 — word-boundary truncation; hard-truncate fallback | `slug.sh` + AC3a/AC3b tests |
| 4 — counter suffix on same-day collision | `skills/notes/SKILL.md` step 6 path bullet |
| 5 — empty slug falls back to body-derived | `slug.sh` + AC5a/AC5b tests |
| 6 — filename never renamed on MATCH | step 5 (unchanged) |
| 7 — index row lookup by pre-rewrite title | step 7 (unchanged) |
| 8 — title trimmed before slugification | `slug.sh` (sed strips leading/trailing `-`) + AC8 test |
| 9 — date prefix prevents cross-day collisions | step 6 path bullet |
| 10 — MATCH/NEW logic unchanged | step 4 + match prompt (unchanged) |
| 11 — slug rule in script, not in-prompt | `scripts/slug.sh` + skill invocation |
| 12 — both empty → exit 1, surfaced as error | `slug.sh` exit codes + skill body |
| 13 — test suite pins core ACs | `tests/slug-test.sh` (13 assertions) |

## Test plan

- [x] `bash tests/slug-test.sh` — 13/13 passing locally.
- [ ] `/note` a verbatim with leading filler — confirm the slug starts with the substantive subject, not stopwords.
- [ ] `/note` a long verbatim where the title slug exceeds 40 chars — confirm truncation lands on a `-` (word boundary).
- [ ] `/note` twice on the same day with the same substantive subject — confirm the second filename gets a `-2` suffix.
- [ ] MATCH-append on an existing note — confirm the filename is not renamed and the index row's title text updates.
- [ ] `wiki-lint` on `notes/` — confirm no false positives (lint matches by frontmatter title, not filename).