### PR TITLE
feat(daily): /daily skill + _shared/capture-pipeline.md extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ wiki/              Claude-generated knowledge base
   sources/         Summaries linked to original materials
 notes/             Inbox: verbatim quick-capture notes (owned by `notes` skill)
   index.md         Pending + Deferred bullet list
+daily/             Chronological daily log (owned by `daily` skill)
+  YYYY-MM-DD.md    One file per day, append-only bullets under ## Captures
 .raw/              Source documents — immutable, never modified by agents
 _templates/        Obsidian Templater templates
 _attachments/      Images and PDFs referenced by wiki pages
@@ -82,6 +84,7 @@ All skills live in `skills/<name>/SKILL.md` and are auto-discovered by Claude Co
 | `lint` | lint the wiki, health check, find orphans, dead links |
 | `save` | `/save`, file this conversation, save insight |
 | `notes` | `/note`, `/dump`, note this, todo:, show my inbox, `/note process` |
+| `daily` | `/daily`, daily note this, log to today, log this, add to today's log |
 | `autoresearch` | autoresearch, autonomous research loop |
 | `canvas` | `/canvas`, add to canvas, create canvas |
 | `defuddle` | clean this url, defuddle, strip clutter |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Then enable the plugin and set `vault_path` (absolute path to your Obsidian vaul
 - `lint` — find orphan pages, dead links, stale claims
 - `save` — save the current conversation or insight into the vault
 - `notes` — quick inbox capture (`/note`, `/dump`); list and process flows for triage
+- `daily` — append-only chronological log (`/daily`); timestamped bullets in `daily/YYYY-MM-DD.md`
 - `autoresearch` — autonomous iterative research loop
 - `canvas` — create / update Obsidian canvas files
 - `defuddle` — strip clutter from web pages before ingestion
@@ -31,11 +32,11 @@ Then enable the plugin and set `vault_path` (absolute path to your Obsidian vaul
 <vault_path>/
   wiki/          agent-generated knowledge (hot.md, index.md, concepts/, entities/, sources/)
   notes/         inbox: verbatim quick-capture notes (owned by `notes` skill)
+  daily/         chronological daily log — one file per day (owned by `daily` skill)
   .raw/          immutable source documents + .manifest.json
   _templates/    Obsidian Templater templates
   _attachments/  images + PDFs referenced by wiki pages
   .obsidian/     (user-owned) Obsidian app config
-  daily/         (optional) daily notes if the user enables them
 ```
 
 ## Hooks

--- a/_seed/daily/example-daily.md
+++ b/_seed/daily/example-daily.md
@@ -1,0 +1,10 @@
+---
+type: daily
+date: 2026-01-01
+created: 2026-01-01
+updated: 2026-01-01
+---
+
+## Captures
+
+- 09:15 example daily entry — replace or delete this file when you start logging

--- a/_shared/capture-pipeline.md
+++ b/_shared/capture-pipeline.md
@@ -7,11 +7,13 @@ Section headings are **stable anchors** — do not reorder. Future splits patch 
 
 ## 1. Vault path resolution
 
-Resolve `<vault_root>` exactly the same way `wiki` does:
+Resolve `<vault_root>` by delegating to `scripts/resolve-vault.sh`, which is the canonical implementation used by `wiki`.
 
-1. Project setting `claude-obsidian.vault_path` (via `~/.claude/settings.local.json`, then `~/.claude/settings.json`).
+Resolution order (matches the script exactly):
+
+1. Legacy explicit path passed as `$1` to `scripts/resolve-vault.sh`, if provided.
 2. CWD if it contains a `wiki/` subdirectory.
-3. `scripts/resolve-vault.sh` (handles all of the above via shell):
+3. Project setting `claude-obsidian.vault_path` (via `~/.claude/settings.local.json`, then `~/.claude/settings.json`).
 
 ```bash
 VAULT=$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh") || {

--- a/_shared/capture-pipeline.md
+++ b/_shared/capture-pipeline.md
@@ -1,0 +1,210 @@
+# Capture Pipeline
+
+Stable contract for all capture surfaces: `/note`, `/daily`, `/braindump` (sub-issue D), and rich inputs (sub-issue E).
+Section headings are **stable anchors** — do not reorder. Future splits patch individual sections in place.
+
+---
+
+## 1. Vault path resolution
+
+Resolve `<vault_root>` exactly the same way `wiki` does:
+
+1. Project setting `claude-obsidian.vault_path` (via `~/.claude/settings.local.json`, then `~/.claude/settings.json`).
+2. CWD if it contains a `wiki/` subdirectory.
+3. `scripts/resolve-vault.sh` (handles all of the above via shell):
+
+```bash
+VAULT=$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh") || {
+  echo "No vault configured — run /wiki init first."
+  exit 1
+}
+```
+
+If no vault is configured, the script exits 1 and prints to stderr. Surface that to the user as:
+
+```
+No vault configured — run /wiki init first.
+```
+
+Do not continue.
+
+---
+
+## 2. Frontmatter schema (note + daily)
+
+Both capture shapes use a flat YAML header per `${CLAUDE_PLUGIN_ROOT}/_shared/frontmatter.md`. Neither shape uses the full wiki universal fields (no `confidence`, `evidence`, `related`, `sources` — those belong on polished wiki pages).
+
+### Note shape (`type: note`)
+
+```yaml
+---
+type: note
+title: "<one-line summary, ≤80 chars>"
+topic: ""
+tags: []
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+source_project: "<cwd basename at capture time>"
+status: pending
+---
+```
+
+- `type: note` — additive to the schema in `_shared/frontmatter.md`; no schema change required.
+- `topic` — optional free-text grouping. Empty by default.
+- `tags` — optional. Empty by default.
+- `source_project` — basename of CWD at capture time; used by LIST `--project=…`.
+- `status` — `pending` | `deferred`. New captures default to `pending`.
+
+### Daily shape (`type: daily`)
+
+```yaml
+---
+type: daily
+date: YYYY-MM-DD
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+```
+
+- `type: daily` — additive to the schema in `_shared/frontmatter.md`; no schema change required.
+- `date` — calendar date this file covers; equals `created`.
+- No `title`, `topic`, `tags`, `source_project`, or `status` — daily files are chronological logs, not knowledge objects.
+
+---
+
+## 3. Slug rule (title-driven)
+
+Slugs are computed by the `slug.sh` script — do not slugify inline:
+
+```bash
+slug=$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/slug.sh" "$title" "$body")
+```
+
+See `scripts/slug.sh` header for the full contract. Exit 1 means both inputs slugify to empty; surface that as an error rather than inventing a name.
+
+The script outputs a lowercase, hyphenated slug (max 40 chars, truncated at the last `-`). This is the canonical slug rule; callers must not duplicate the logic.
+
+Note files use slug in the filename: `<vault_root>/notes/YYYY-MM-DD-<slug>.md`. Daily files do not use a slug — their filename is the date: `<vault_root>/daily/YYYY-MM-DD.md`.
+
+---
+
+## 4. MATCH/NEW heuristic (incl. prompt template)
+
+Used by `/note` CAPTURE only. `/daily` is append-only (no MATCH/NEW — see §7).
+
+### Enumeration
+
+List `<vault_root>/notes/*.md` and read **frontmatter only** for each (title, topic, tags). Skip bodies. Skip `notes/index.md` and any file with `status: deferred`. Cap at the **20 most recent by `updated:`**. Use `mcp__obsidian-vault__obsidian_batch_get_file_contents` when the MCP server is available.
+
+### Decision prompt
+
+```
+Existing notes (frontmatter only):
+{{for each candidate, render: filename, title, topic, tags}}
+
+New note text:
+"""
+{{verbatim user text}}
+"""
+
+Decide:
+- MATCH: <filename> | <one sentence why> — only if a single candidate clearly
+  extends or near-duplicates the new content. Required signals (ALL must hold):
+    1. (title alignment) OR (topic alignment) — same subject, not just same domain.
+    2. (tag overlap ≥ 1) OR (tags empty on both, AND title/topic alignment is strong).
+    3. The new content is a logical extension of the existing scope (continuation,
+       counter-example, follow-up question on the same thing) — not a new thread.
+- NEW — anything ambiguous, weak, cross-cutting, contradictory, or where two
+  candidates plausibly fit. The bar is high; default to NEW under doubt.
+```
+
+Output exactly one of `MATCH: <filename> | <reason>` or `NEW`. Use `MATCH` only when one candidate stands out clearly; if two plausibly fit, output `NEW`.
+
+### MATCH path
+
+Append to the existing file:
+
+```
+<existing body>
+
+---
+
+<new verbatim text>
+```
+
+If the new content broadens the note's scope, rewrite `title:` to cover the union. Bump `updated:` to today. `topic:` and `tags:` may be widened; never narrowed. Filename is **never renamed**.
+
+### NEW path
+
+1. Derive a one-line title (≤80 chars), stripping filler ("we need to", "can we check", "I think we should"). If the verbatim text is short, substantive, and one-line, use it directly.
+2. Compute slug per §3.
+3. Path: `<vault_root>/notes/YYYY-MM-DD-<slug>.md`. If it exists for today, append `-2`, `-3`, …
+4. Frontmatter from §2 note shape; body is the verbatim text.
+
+---
+
+## 5. Attachment handling (placeholder for sub-issue E)
+
+Reserved for #64 — image input across capture skills.
+
+---
+
+## 6. Index patching (notes/index.md)
+
+Patch in place after every CAPTURE — never rewrite from scratch.
+
+**NEW:** prepend a row under `## Pending`:
+
+```
+- [ ] YYYY-MM-DD [<source_project>] <title>
+```
+
+**MATCH:** find the row by the **pre-rewrite title** (the title the file had before this operation). Bump its date to today; if the title was rewritten, replace the title text. Never add a duplicate row.
+
+Row format: `- [ ] YYYY-MM-DD [source_project] title` (pending) or `- [~] YYYY-MM-DD [source_project] title` (deferred).
+
+`notes/index.md` canonical template lives at `_seed/notes/index.md`. Two static sections: `## Pending` and `## Deferred`. Updated on every CAPTURE and PROCESS action. Mirror the patch-in-place pattern used by `/save` and `/ingest`.
+
+---
+
+## 7. Daily page append shape
+
+File path: `<vault_root>/daily/YYYY-MM-DD.md`
+
+### File creation (first call for the day)
+
+If `<vault_root>/daily/` does not exist, create it silently (never abort). Then create the file with frontmatter from §2 daily shape plus an empty `## Captures` section:
+
+```markdown
+---
+type: daily
+date: YYYY-MM-DD
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+## Captures
+
+```
+
+### Append rule
+
+Append one bullet under `## Captures`:
+
+```
+- HH:MM <verbatim text>
+```
+
+`HH:MM` is the **local-time** hour:minute at append (24-hour clock, zero-padded). No rounding, no counter on duplicate timestamps.
+
+If `## Captures` heading is missing from an existing file, append it at EOF before the bullet (idempotent — never duplicate the heading).
+
+### Idempotency
+
+- One new bullet per invocation, no deduplication.
+- Multiple calls in the same minute land bullets with the same `HH:MM` prefix in file order — no collision handling.
+- `updated:` in frontmatter is bumped to today on every append.
+
+### No MATCH/NEW
+
+Every `/daily` call adds a new bullet. No candidate enumeration, no MATCH/NEW decision, no index patching. Daily files are chronological logs, not knowledge objects.

--- a/commands/daily.md
+++ b/commands/daily.md
@@ -1,0 +1,8 @@
+---
+description: Append a timestamped bullet to today's daily log in the vault.
+argument-hint: "<verbatim text>"
+---
+
+Read the `daily` skill. Then run the CAPTURE operation with the argument as the verbatim text. Append one bullet `- HH:MM <text>` under `## Captures` in `<vault_root>/daily/YYYY-MM-DD.md`. Create the directory and file if missing.
+
+If the argument is empty, surface: `Usage: /daily <verbatim text>`. If no vault is configured, surface: `No vault configured — run /wiki init first.`

--- a/skills/daily/SKILL.md
+++ b/skills/daily/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: daily
 description: >
-  Append a timestamped bullet to today's daily log in the vault. Append-only
-  chronological capture — no MATCH/NEW decision, no inbox triage. Fast path for
-  progress notes, time-anchored observations, and in-the-moment thoughts.
+  Append a timestamped bullet to today's daily log in the vault. Each call
+  adds one line to <vault_root>/daily/YYYY-MM-DD.md — no inbox, no triage.
   Triggers on: "/daily", "daily note this", "log to today", "log this",
   "add to today's log", "daily log:".
 allowed-tools: Read Write Edit Bash

--- a/skills/daily/SKILL.md
+++ b/skills/daily/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: daily
+description: >
+  Append a timestamped bullet to today's daily log in the vault. Append-only
+  chronological capture — no MATCH/NEW decision, no inbox triage. Fast path for
+  progress notes, time-anchored observations, and in-the-moment thoughts.
+  Triggers on: "/daily", "daily note this", "log to today", "log this",
+  "add to today's log", "daily log:".
+allowed-tools: Read Write Edit Bash
+---
+
+# daily: Chronological Daily Log
+
+Append a timestamped bullet to `<vault_root>/daily/YYYY-MM-DD.md`. No MATCH/NEW decision, no inbox, no triage. Every invocation adds one bullet. Use `/note` for knowledge fragments worth triaging later; use `/daily` for time-anchored observations, progress notes, and anything that belongs to the day.
+
+---
+
+## Vault path
+
+See [§1 Vault path resolution](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). If no vault is configured, abort with:
+
+```
+No vault configured — run /wiki init first.
+```
+
+---
+
+## Operations
+
+| User says | Operation |
+|-----------|-----------|
+| `/daily <text>`, `"daily note this …"`, `"log to today …"`, `"log this …"`, `"add to today's log …"`, `"daily log: …"` | CAPTURE |
+
+No LIST, no PROCESS. Daily files are an append-only log — triage and synthesis are handled by `/daily-close` (sub-issue C).
+
+---
+
+## CAPTURE Operation
+
+Steps:
+
+1. **Extract** the verbatim text from the user's message. Everything after the trigger phrase, preserved exactly — no rewriting, no summarising.
+2. **Resolve** `<vault_root>` per [§1](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). Abort with `No vault configured — run /wiki init first.` if unresolved.
+3. **Compute** today as `YYYY-MM-DD` and current local time as `HH:MM` (24-hour, zero-padded).
+4. **Ensure directory:** if `<vault_root>/daily/` does not exist, create it silently.
+5. **Ensure file:** if `<vault_root>/daily/YYYY-MM-DD.md` does not exist, create it per [§7 Daily page append shape](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#7-daily-page-append-shape) — frontmatter from [§2](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#2-frontmatter-schema-note--daily) plus an empty `## Captures` section.
+6. **Ensure heading:** if the file exists but `## Captures` is missing, append the heading at EOF before the bullet (idempotent — never duplicate).
+7. **Append** one bullet under `## Captures`:
+   ```
+   - HH:MM <verbatim text>
+   ```
+8. **Bump** `updated:` in frontmatter to today.
+9. **Confirm** with exactly one line:
+   ```
+   Logged to daily/YYYY-MM-DD.md
+   ```
+
+Do **not** print the diff, the reasoning, or any other output. One line only.
+
+### Idempotency and collision rules
+
+Per [§7](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#7-daily-page-append-shape):
+
+- Multiple calls in the same minute land bullets with the same `HH:MM` prefix in file order — no collision handling, no counter.
+- No MATCH/NEW decision runs — every call adds a new bullet.
+
+---
+
+## Frontmatter schema
+
+See [§2 Frontmatter schema — daily shape](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#2-frontmatter-schema-note--daily).
+
+---
+
+## Examples
+
+**First call of the day (file does not exist):**
+```
+user> /daily shipped the /note slug rewrite
+# daily/2026-04-27.md created with frontmatter + ## Captures heading
+assistant> Logged to daily/2026-04-27.md
+```
+
+**Subsequent call (file exists, heading present):**
+```
+user> log to today: pairing session with @dana on the wiki lint refactor
+# one bullet appended under ## Captures
+assistant> Logged to daily/2026-04-27.md
+```
+
+**Two calls in the same minute:**
+```
+user> /daily standup done
+assistant> Logged to daily/2026-04-27.md
+
+user> daily note this: retrospective rescheduled to Thursday
+assistant> Logged to daily/2026-04-27.md
+# both bullets share the same HH:MM prefix — acceptable
+```
+
+**No vault configured:**
+```
+user> /daily fixed the flaky test
+assistant> No vault configured — run /wiki init first.
+```

--- a/skills/notes/SKILL.md
+++ b/skills/notes/SKILL.md
@@ -22,9 +22,7 @@ The wiki is the polished knowledge base. `notes/` is the inbox. Keep them separa
 
 ## Vault path
 
-Resolve `<vault_root>` exactly the same way `wiki` does — project setting `claude-obsidian.vault_path` first, then CWD if it contains `wiki/`, then settings files via `${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh`. **Always write to `<vault_root>/notes/`** regardless of CWD. The `source_project` field records where the user was when capturing.
-
-If no vault is configured, abort with `No vault configured — run /wiki init first.`
+See [§1 Vault path resolution](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). Always write to `<vault_root>/notes/` regardless of CWD. If no vault is configured, abort with `No vault configured — run /wiki init first.`
 
 ---
 
@@ -47,60 +45,15 @@ Goal: persist the user's verbatim text with minimal metadata. No conversation co
 Steps:
 
 1. **Extract** the verbatim text from the user's message. For `/note <text>` and `/dump <text>`, the text is everything after the trigger. For natural-language triggers (`"note this: …"`, `"todo: …"`), extract the substring after the trigger phrase. Preserve the original wording exactly — no rewriting, no summarising.
-2. **Resolve** `<vault_root>` (see Vault path). Compute today's date as `YYYY-MM-DD`. Compute `source_project = basename(cwd)`. If `<vault_root>/notes/` does not exist, create the directory and initialise `notes/index.md` from the template in the `## notes/index.md` section below; then continue.
-3. **Enumerate** existing notes by listing `<vault_root>/notes/*.md` and reading **frontmatter only** for each (title, topic, tags). Skip bodies — they bloat the prompt and aren't needed for the match decision. Skip `notes/index.md` and any file with `status: deferred`. (Deferred notes are excluded intentionally: the user set them aside; routing new content into them would silently overturn that decision.) Cap candidates at the **20 most recent by `updated:`** — older notes rarely match new captures and inflate the prompt. Use `mcp__obsidian-vault__obsidian_batch_get_file_contents` when the MCP server is available to read frontmatter in one call.
-4. **Decide MATCH or NEW** using the prompt template below. The bar is intentionally high; misroutes cost more than duplicates because the user does not see the decision at capture time.
-5. **MATCH path** — append to the existing file:
-   - Add a separator + the new verbatim chunk to the body:
-     ```
-     <existing body>
-
-     ---
-
-     <new verbatim text>
-     ```
-   - If the new content broadens the note's scope, **rewrite `title:`** to a phrase covering the union. Bump `updated:` to today. Frontmatter `topic:` and `tags:` may be widened as needed; never narrowed.
-   - **Filename is never renamed.** Drift between filename slug and rewritten `title` is acceptable.
-6. **NEW path** — create a new file:
-   - **Title.** Derive a one-line summary (≤80 chars) of the verbatim text, stripping leading filler ("we need to", "can we check", "I think we should") so the substance leads. If the verbatim text is itself short, substantive, and one-line, use it as the title.
-   - **Slug.** Compute via `bash ${CLAUDE_PLUGIN_ROOT}/scripts/slug.sh "$title" "$body"` — see that script's header for the contract. Do not slugify in-prompt. Exit 1 means both inputs slugify to empty; surface that as an error rather than inventing a name.
-   - **Path:** `<vault_root>/notes/YYYY-MM-DD-<slug>.md`. If that filename already exists for today, append a counter suffix `-2`, `-3`, … incrementing. Different days never collide because the date prefix differs.
-   - **Frontmatter** from the template below; body is the verbatim text. Topic and tags may be left empty (`""` and `[]`) — they're populated by the user later if needed.
-7. **Update `notes/index.md`** — patch in place, no full rewrite:
-   - On NEW: prepend a row under `## Pending`.
-   - On MATCH: find the existing row by the **pre-rewrite title** (the title the file had before this operation). Bump its date to today; if the title was rewritten, replace the title text. Never add a duplicate row.
-   - Format: `- [ ] YYYY-MM-DD [<source_project>] <title>`.
-8. **Confirm** with one terse line. Two shapes only:
+2. **Resolve** `<vault_root>` per [§1](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). Compute today's date as `YYYY-MM-DD`. Compute `source_project = basename(cwd)`. If `<vault_root>/notes/` does not exist, create the directory and initialise `notes/index.md` from the template at `_seed/notes/index.md`; then continue.
+3. **Enumerate** existing notes and decide MATCH or NEW per [§4 MATCH/NEW heuristic](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#4-matchnew-heuristic-incl-prompt-template).
+4. **MATCH path** or **NEW path** — follow [§4](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#4-matchnew-heuristic-incl-prompt-template) exactly. Slug computation uses [§3 Slug rule](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#3-slug-rule-title-driven).
+5. **Update `notes/index.md`** per [§6 Index patching](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#6-index-patching-notesindexmd).
+6. **Confirm** with one terse line. Two shapes only:
    - NEW: `Captured to notes/YYYY-MM-DD-<slug>.md`
    - MATCH: `Appended to notes/YYYY-MM-DD-<slug>.md`
 
 Do **not** print the diff, the match reasoning, or the candidate list. Capture is a fire-and-forget action.
-
-### Match prompt template
-
-When CAPTURE step 3 enumerates candidates, run this decision in your head before writing. Output exactly one of `MATCH: <filename> | <reason>` or `NEW`.
-
-```
-Existing notes (frontmatter only):
-{{for each candidate, render: filename, title, topic, tags}}
-
-New note text:
-"""
-{{verbatim user text}}
-"""
-
-Decide:
-- MATCH: <filename> | <one sentence why> — only if a single candidate clearly
-  extends or near-duplicates the new content. Required signals (ALL must hold):
-    1. (title alignment) OR (topic alignment) — same subject, not just same domain.
-    2. (tag overlap ≥ 1) OR (tags empty on both, AND title/topic alignment is strong).
-    3. The new content is a logical extension of the existing scope (continuation,
-       counter-example, follow-up question on the same thing) — not a new thread.
-- NEW — anything ambiguous, weak, cross-cutting, contradictory, or where two
-  candidates plausibly fit. The bar is high; default to NEW under doubt.
-```
-
-Use `MATCH` only when one candidate stands out clearly. If two candidates both look plausible, output `NEW` — duplicates are recoverable, misroutes are silent.
 
 ---
 
@@ -160,26 +113,9 @@ Steps:
 
 ---
 
-## Frontmatter Template
+## Frontmatter schema
 
-```yaml
----
-type: note
-title: "<one-line summary, ≤80 chars>"
-topic: ""
-tags: []
-created: YYYY-MM-DD
-updated: YYYY-MM-DD
-source_project: "<cwd basename at capture time>"
-status: pending
----
-```
-
-- `type: note` — additive value to the schema in `${CLAUDE_PLUGIN_ROOT}/_shared/frontmatter.md`. No schema change required.
-- `topic` — optional free-text grouping (e.g. `"vault tooling"`, `"workflow ergonomics"`). Empty by default.
-- `tags` — optional. Empty by default. Populated later by the user if useful.
-- `source_project` — basename of CWD at capture time. Used by `LIST --project=…`.
-- `status` — `pending` | `deferred`. New captures default to `pending`.
+See [§2 Frontmatter schema — note shape](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#2-frontmatter-schema-note--daily).
 
 The body is the user's verbatim text. No headings, no metadata in the body. On MATCH-append, the separator is a blank line + `---` + blank line, then the new verbatim chunk.
 
@@ -187,16 +123,7 @@ The body is the user's verbatim text. No headings, no metadata in the body. On M
 
 ## `notes/index.md`
 
-Canonical template lives at `_seed/notes/index.md` (copied during `/wiki init`). Two static sections — `## Pending` and `## Deferred`. No project subgroups.
-
-Row format:
-
-```
-- [ ] 2026-04-25 [claude-obsidian] /note process should reuse confidence threshold
-- [~] 2026-04-22 [scripts] old idea, deferred — revisit Q3
-```
-
-Patch the index on every CAPTURE/PROCESS action — never re-render from scratch. Mirror the patch-in-place pattern used by `/save` and `/ingest`. The index is the single source of truth at this scale; `/wiki lint` is the safety net for drift.
+See [§6 Index patching](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#6-index-patching-notesindexmd). Canonical template lives at `_seed/notes/index.md` (copied during `/wiki init`).
 
 ---
 

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -121,11 +121,12 @@ Steps:
 4. Create domain pages + `_index.md` sub-indexes.
 5. Create `wiki/index.md`, `wiki/log.md`, `wiki/hot.md`, `wiki/overview.md`.
 6. Create `notes/` (top-level peer of `wiki/`) and copy `_seed/notes/index.md` if missing — this is the inbox owned by the `notes` skill.
-7. Create `_templates/` files for each note type.
-8. Apply visual customization. Read `references/css-snippets.md`. Create `.obsidian/snippets/vault-colors.css`.
-9. Create the vault CLAUDE.md using the template below.
-10. Initialize git. Read `references/git-setup.md`.
-11. Present the structure and ask: "Want to adjust anything before we start?"
+7. Create `daily/` (top-level peer of `wiki/`) and copy `_seed/daily/example-daily.md` if the directory is missing — this is the append-only log owned by the `daily` skill. If `daily/` already exists, skip without disturbing existing files.
+8. Create `_templates/` files for each note type.
+9. Apply visual customization. Read `references/css-snippets.md`. Create `.obsidian/snippets/vault-colors.css`.
+10. Create the vault CLAUDE.md using the template below.
+11. Initialize git. Read `references/git-setup.md`.
+12. Present the structure and ask: "Want to adjust anything before we start?"
 
 ### Vault CLAUDE.md Template
 


### PR DESCRIPTION
## Summary

- Adds `skills/daily/SKILL.md` — append-only chronological log skill that writes `- HH:MM <text>` bullets to `<vault_root>/daily/YYYY-MM-DD.md` with no MATCH/NEW decision or inbox triage
- Extracts `_shared/capture-pipeline.md` with seven stable section anchors (`§1` vault path … `§7` daily page shape) as the single canonical contract for all capture surfaces (`/note`, `/daily`, and future `/braindump`, rich inputs)
- Reduces `skills/notes/SKILL.md` to inbox-glue only — inline vault-path, frontmatter, slug, MATCH/NEW, and index-patching prose replaced with anchor refs to the shared file
- Extends `skills/wiki/SKILL.md` SCAFFOLD step 7 to create `daily/` and seed it from `_seed/daily/example-daily.md`
- Adds `daily/` to vault structure blocks in `CLAUDE.md` and `README.md`

## Manual testing

1. **`/daily` CAPTURE — first call of the day:**
   - Ensure vault is configured (`claude-obsidian.vault_path` set or CWD contains `wiki/`)
   - Run `/daily standup done`
   - Verify `<vault_root>/daily/YYYY-MM-DD.md` is created with correct frontmatter (`type: daily`, `date`, `created`, `updated`) and a `## Captures` heading
   - Verify one bullet `- HH:MM standup done` is appended

2. **`/daily` CAPTURE — subsequent call:**
   - Run `/daily pairing session with dana`
   - Verify a second bullet is appended under `## Captures`, same file, `updated:` bumped

3. **`/daily` — missing `daily/` directory:**
   - Remove `<vault_root>/daily/` if it exists
   - Run `/daily test after rm`
   - Verify directory and file are created silently, bullet appended, output is exactly `Logged to daily/YYYY-MM-DD.md`

4. **`/daily` — no vault configured:**
   - Temporarily unset vault config or run from a directory without `wiki/`
   - Run `/daily anything`
   - Verify output is `No vault configured — run /wiki init first.`

5. **`/note` backwards compatibility:**
   - Run `/note this is an inbox note`
   - Verify it captures to `notes/` as before — no change to output, no routing to `daily/`

6. **`/wiki init` seeds `daily/`:**
   - Run `/wiki init` against a fresh or existing vault
   - Verify `<vault_root>/daily/` exists after init; existing files are undisturbed

7. **`_shared/capture-pipeline.md` anchor integrity:**
   - Open `_shared/capture-pipeline.md` and verify all seven `## 1` … `## 7` headings are present in order

Closes #62