### PR TITLE
feat(braindump): /braindump skill — long-form text → atomic-thought split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ All skills live in `skills/<name>/SKILL.md` and are auto-discovered by Claude Co
 | `save` | `/save`, file this conversation, save insight |
 | `notes` | `/note`, `/dump`, note this, todo:, show my inbox, `/note process` |
 | `daily` | `/daily`, daily note this, log to today, log this, add to today's log |
+| `braindump` | `/braindump`, brain dump this, dump the following thoughts, braindump: |
 | `autoresearch` | autoresearch, autonomous research loop |
 | `canvas` | `/canvas`, add to canvas, create canvas |
 | `defuddle` | clean this url, defuddle, strip clutter |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ All skills live in `skills/<name>/SKILL.md` and are auto-discovered by Claude Co
 | `save` | `/save`, file this conversation, save insight |
 | `notes` | `/note`, `/dump`, note this, todo:, show my inbox, `/note process` |
 | `daily` | `/daily`, daily note this, log to today, log this, add to today's log |
-| `braindump` | `/braindump`, brain dump this, dump the following thoughts, braindump: |
+| `braindump` | `/braindump`, brain dump this, dump the following thoughts, dump these thoughts, braindump:, split this into notes |
 | `autoresearch` | autoresearch, autonomous research loop |
 | `canvas` | `/canvas`, add to canvas, create canvas |
 | `defuddle` | clean this url, defuddle, strip clutter |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then enable the plugin and set `vault_path` (absolute path to your Obsidian vaul
 - `save` — save the current conversation or insight into the vault
 - `notes` — quick inbox capture (`/note`, `/dump`); list and process flows for triage
 - `daily` — append-only chronological log (`/daily`); timestamped bullets in `daily/YYYY-MM-DD.md`
-- `braindump` — split long-form text into atomic notes (`/braindump`); each chunk filed via the full capture pipeline
+- `braindump` — split long-form text into atomic notes (`/braindump`, "brain dump this", "split this into notes"); each chunk filed via the full capture pipeline
 - `autoresearch` — autonomous iterative research loop
 - `canvas` — create / update Obsidian canvas files
 - `defuddle` — strip clutter from web pages before ingestion

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Then enable the plugin and set `vault_path` (absolute path to your Obsidian vaul
 - `save` — save the current conversation or insight into the vault
 - `notes` — quick inbox capture (`/note`, `/dump`); list and process flows for triage
 - `daily` — append-only chronological log (`/daily`); timestamped bullets in `daily/YYYY-MM-DD.md`
+- `braindump` — split long-form text into atomic notes (`/braindump`); each chunk filed via the full capture pipeline
 - `autoresearch` — autonomous iterative research loop
 - `canvas` — create / update Obsidian canvas files
 - `defuddle` — strip clutter from web pages before ingestion

--- a/skills/braindump/SKILL.md
+++ b/skills/braindump/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: braindump
+description: >
+  Split a long-form text stream into atomic thoughts and file each as a
+  separate inbox note — without breaking flow. Accepts inline text or a
+  file path (vault-relative or absolute). Each chunk goes through the full
+  CAPTURE pipeline (MATCH/NEW per chunk). Triage later via /note process.
+  Triggers on: "/braindump", "brain dump this", "dump the following thoughts",
+  "dump these thoughts", "braindump:", "split this into notes".
+allowed-tools: Read Write Edit Glob Grep Bash
+---
+
+# braindump: Long-Form → Atomic Notes
+
+`/note` is for one thought at a time. `/braindump` is for when you couldn't stop to format — planning sessions, end-of-feature retros, design ramblings. It takes the whole stream, splits it into atomic thoughts via a single LLM reasoning step, and feeds each chunk through the standard CAPTURE pipeline. The chunks land in `notes/` like any `/note` capture. Triage them later with `/note process`.
+
+---
+
+## Vault path
+
+See [§1 Vault path resolution](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). If no vault is configured, abort with:
+
+```
+No vault configured — run /wiki init first.
+```
+
+---
+
+## Input parsing
+
+The argument to `/braindump` is positional — either inline text or a file path. Resolution order:
+
+1. If `<arg>` is empty or whitespace-only → abort:
+   ```
+   /braindump requires text or a file path.
+   ```
+2. Resolve as a path: absolute when `<arg>` starts with `/`; otherwise relative to `<vault_root>` (not CWD).
+3. If the resolved path points to a readable regular file:
+   - **Text test:** file extension is `.md`, `.txt`, or `.markdown` **OR** the first 4 KB decodes as valid UTF-8.
+   - Text file → use the file's contents as the dump body.
+   - Binary file → abort:
+     ```
+     Binary inputs not supported in /braindump — wait for sub-issue E (rich capture inputs).
+     ```
+4. Otherwise (path does not resolve, or looks like a path but isn't) → treat `<arg>` verbatim as inline text. No error — text-that-looks-like-a-path is valid input.
+
+---
+
+## Split — atomic-thought rubric
+
+Pass the dump body to a **single LLM reasoning step** (think step, not a separate tool call) with this rubric:
+
+> **Atomic thought** = one self-contained idea, observation, question, or proposal. Think Zettelkasten: one thought per note.
+>
+> **Split when:** topic, claim, or referent shifts in a way that would warrant a separate note.
+>
+> **Do not split:** mid-claim, mid-example, or mid-argument. Don't break a single idea into pieces just because it is long.
+>
+> **Do not merge:** two distinct claims or questions into one chunk, even if they share a domain.
+>
+> **Preserve verbatim:** boundaries are chosen, content is unchanged. Each chunk preserves the user's exact wording for that thought — no rewriting, no summarising.
+>
+> **Single thought in → single chunk out.** Do not introduce spurious splits.
+
+Output: an ordered list of chunks (strings). Each chunk is a verbatim excerpt from the original dump.
+
+**If split returns zero chunks** (LLM error, empty result, or the body is blank after parsing) → abort:
+```
+/braindump split returned no chunks. Original text not captured.
+```
+Never silently lose the dump.
+
+---
+
+## CAPTURE loop
+
+For each chunk in order:
+
+1. **Resolve vault** and enumerate `<vault_root>/notes/*.md` fresh (read frontmatter only). Candidates include notes written by earlier chunks in this same `/braindump` call — re-reading per chunk implements AC-14 (chunk K can MATCH-append to a chunk K-1 NEW note) for free.
+2. **MATCH/NEW decision** per [§4 MATCH/NEW heuristic](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#4-matchnew-heuristic-incl-prompt-template). Skip `notes/index.md` and `status: deferred` notes; cap candidates at 20 most recent by `updated:`.
+3. **MATCH path** or **NEW path** exactly per [§4](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#4-matchnew-heuristic-incl-prompt-template), slug via [§3](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#3-slug-rule-title-driven).
+4. **Index patch** per [§6 Index patching](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#6-index-patching-notesindexmd).
+5. **Record** the resulting filename and a success/failure flag in an ordered list.
+6. **On per-chunk write or index error:** append to failure list, continue remaining chunks. Never abort the loop on a single failure.
+
+`source_project` for each chunk = `basename(cwd)` at invoke time, same as `/note`.
+
+---
+
+## Confirmation output
+
+After the loop completes:
+
+```
+Captured N notes:
+- notes/YYYY-MM-DD-<slug>.md
+- notes/YYYY-MM-DD-<slug2>.md
+…
+```
+
+Filenames in chunk order. No NEW/MATCH labels — silent routing principle. No diff. No reasoning.
+
+If any chunks failed (per AC-13):
+
+```
+Captured N notes:
+- notes/YYYY-MM-DD-<slug>.md
+…
+
+Failed: K chunks. <one-line reason per failure>
+```
+
+---
+
+## Frontmatter schema
+
+Chunks use the note shape (`type: note`) per [§2 Frontmatter schema](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#2-frontmatter-schema-note--daily). No special braindump provenance or metadata — chunks are indistinguishable from `/note` captures once filed. This means `/note process` can triage them without any special handling.
+
+---
+
+## Examples
+
+**Inline text, multi-thought:**
+```
+user> /braindump I keep forgetting to check the lint score before PRs. Also need to revisit the hot cache size — it's been growing. And the daily skill confirmation message looks wrong in dark mode.
+# Split: 3 chunks (3 distinct observations)
+assistant>
+Captured 3 notes:
+- notes/2026-04-27-check-lint-score-before-prs.md
+- notes/2026-04-27-hot-cache-size-growing.md
+- notes/2026-04-27-daily-skill-confirmation-dark-mode.md
+```
+
+**Single thought (no spurious split):**
+```
+user> /braindump The slug truncation rule needs to account for multi-byte unicode characters — right now it can split in the middle of a grapheme cluster, which breaks vault filenames on some filesystems.
+# Split: 1 chunk (single atomic idea, just long)
+assistant>
+Captured 1 notes:
+- notes/2026-04-27-slug-truncation-multibyte-unicode.md
+```
+
+**File input (vault-relative):**
+```
+user> /braindump retro-notes/2026-04-feature-retro.txt
+# File resolved as <vault_root>/retro-notes/2026-04-feature-retro.txt
+# Contents split into N chunks
+assistant>
+Captured N notes:
+- notes/2026-04-27-…
+…
+```
+
+**No vault:**
+```
+user> /braindump some thoughts
+assistant> No vault configured — run /wiki init first.
+```
+
+**Empty body:**
+```
+user> /braindump
+assistant> /braindump requires text or a file path.
+```
+
+**Binary file:**
+```
+user> /braindump _attachments/diagram.png
+assistant> Binary inputs not supported in /braindump — wait for sub-issue E (rich capture inputs).
+```
+
+**One chunk fails (filesystem error):**
+```
+assistant>
+Captured 2 notes:
+- notes/2026-04-27-check-lint-score-before-prs.md
+- notes/2026-04-27-daily-skill-confirmation-dark-mode.md
+
+Failed: 1 chunks. notes/: permission denied writing 2026-04-27-hot-cache-size-growing.md
+```

--- a/skills/braindump/SKILL.md
+++ b/skills/braindump/SKILL.md
@@ -12,123 +12,87 @@ allowed-tools: Read Write Edit Glob Grep Bash
 
 # braindump: Long-Form → Atomic Notes
 
-`/note` is for one thought at a time. `/braindump` is for when you couldn't stop to format — planning sessions, end-of-feature retros, design ramblings. It takes the whole stream, splits it into atomic thoughts via a single LLM reasoning step, and feeds each chunk through the standard CAPTURE pipeline. The chunks land in `notes/` like any `/note` capture. Triage them later with `/note process`.
+Long-form text that shouldn't interrupt flow — planning sessions, retros, design ramblings. `/braindump` splits the stream into atomic thoughts and files each through the standard CAPTURE pipeline. Chunks land in `notes/` indistinguishable from `/note` captures; triage with `/note process`.
 
 ---
 
 ## Vault path
 
-See [§1 Vault path resolution](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). If no vault is configured, abort with:
-
-```
-No vault configured — run /wiki init first.
-```
+See [§1 Vault path resolution](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). If no vault is configured, abort with `No vault configured — run /wiki init first.`
 
 ---
 
 ## Input parsing
 
-The argument to `/braindump` is positional — either inline text or a file path. Resolution order:
+Positional argument — inline text or file path:
 
-1. If `<arg>` is empty or whitespace-only → abort:
-   ```
-   /braindump requires text or a file path.
-   ```
-2. Resolve as a path: absolute when `<arg>` starts with `/`; otherwise relative to `<vault_root>` (not CWD).
-3. If the resolved path points to a readable regular file:
-   - **Text test:** file extension is `.md`, `.txt`, or `.markdown` **OR** the first 4 KB decodes as valid UTF-8.
-   - Text file → use the file's contents as the dump body.
-   - Binary file → abort:
-     ```
-     Binary inputs not supported in /braindump — wait for sub-issue E (rich capture inputs).
-     ```
-4. Otherwise (path does not resolve, or looks like a path but isn't) → treat `<arg>` verbatim as inline text. No error — text-that-looks-like-a-path is valid input.
+1. Empty or whitespace-only → abort: `/braindump requires text or a file path.`
+2. Resolve as path: absolute when `<arg>` starts with `/`; otherwise relative to `<vault_root>` (not CWD).
+3. Path resolves to a readable regular file:
+   - Text if extension is `.md`, `.txt`, or `.markdown` **OR** first 4 KB decodes as UTF-8 → use file contents as body.
+   - Binary → abort: `Binary inputs not supported in /braindump — wait for sub-issue E (rich capture inputs).`
+4. Path does not resolve → treat `<arg>` verbatim as inline text. No error.
 
 ---
 
 ## Split — atomic-thought rubric
 
-Pass the dump body to a **single LLM reasoning step** (think step, not a separate tool call) with this rubric:
+Single LLM reasoning step (think step, not a tool call):
 
 > **Atomic thought** = one self-contained idea, observation, question, or proposal. Think Zettelkasten: one thought per note.
 >
 > **Split when:** topic, claim, or referent shifts in a way that would warrant a separate note.
 >
-> **Do not split:** mid-claim, mid-example, or mid-argument. Don't break a single idea into pieces just because it is long.
+> **Do not split** mid-claim, mid-example, or mid-argument. **Do not merge** two distinct claims. **Single thought in → single chunk out.**
 >
-> **Do not merge:** two distinct claims or questions into one chunk, even if they share a domain.
->
-> **Preserve verbatim:** boundaries are chosen, content is unchanged. Each chunk preserves the user's exact wording for that thought — no rewriting, no summarising.
->
-> **Single thought in → single chunk out.** Do not introduce spurious splits.
+> **Preserve verbatim:** boundaries are chosen, content is unchanged.
 
-Output: an ordered list of chunks (strings). Each chunk is a verbatim excerpt from the original dump.
-
-**If split returns zero chunks** (unexpected empty result from the reasoning step, or the body is blank after parsing) → hard-abort immediately, no retry:
-```
-/braindump split returned no chunks. Original text not captured.
-```
-Never silently lose the dump.
+Zero chunks (unexpected empty result from the reasoning step) → hard-abort, no retry: `/braindump split returned no chunks. Original text not captured.`
 
 ---
 
 ## CAPTURE loop
 
-For each chunk in order:
+For each chunk in order, re-enumerate `<vault_root>/notes/*.md` fresh (so chunk K can MATCH-append to a note written by chunk K-1). Then:
 
-1. **Resolve vault** and enumerate `<vault_root>/notes/*.md` fresh (read frontmatter only). Candidates include notes written by earlier chunks in this same `/braindump` call — re-reading per chunk implements AC-14 (chunk K can MATCH-append to a chunk K-1 NEW note) for free.
-2. **MATCH/NEW decision** per [§4 MATCH/NEW heuristic](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#4-matchnew-heuristic-incl-prompt-template). Skip `notes/index.md` and `status: deferred` notes; cap candidates at 20 most recent by `updated:`.
-3. **MATCH path** or **NEW path** exactly per [§4](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#4-matchnew-heuristic-incl-prompt-template), slug via [§3](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#3-slug-rule-title-driven).
-4. **Index patch** per [§6 Index patching](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#6-index-patching-notesindexmd).
-5. **Record** the resulting filename and a success/failure flag in an ordered list.
-6. **On per-chunk write or index error:** append to failure list, continue remaining chunks. Never abort the loop on a single failure.
+1. MATCH/NEW per [§4](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#4-matchnew-heuristic-incl-prompt-template) — skip `notes/index.md` and `status: deferred`; cap at 20 most recent.
+2. MATCH or NEW path per [§4](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#4-matchnew-heuristic-incl-prompt-template); slug via [§3](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#3-slug-rule-title-driven).
+3. Index patch per [§6](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#6-index-patching-notesindexmd).
+4. Record filename + success/failure. On error: append to failure list, continue — never abort the loop.
 
-`source_project` for each chunk = `basename(cwd)` at invoke time, same as `/note`.
+`source_project` = `basename(cwd)`. Frontmatter: note shape from [§2](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#2-frontmatter-schema-note--daily), no braindump provenance.
 
 ---
 
 ## Confirmation output
 
-After the loop completes:
-
 ```
-Captured N notes:
+Captured N notes:            ← "note" singular when N=1
 - notes/YYYY-MM-DD-<slug>.md
-- notes/YYYY-MM-DD-<slug2>.md
 …
 ```
 
-Use `note` (singular) when N=1, `notes` (plural) otherwise. Filenames in chunk order. No NEW/MATCH labels — silent routing principle. No diff. No reasoning.
+No NEW/MATCH labels. No diff. No reasoning.
 
-If any chunks failed (per AC-13):
+If any chunks failed:
 
 ```
 Captured N notes:
 - notes/YYYY-MM-DD-<slug>.md
 …
 
-Failed: K chunks.
-- <one-line reason for failure 1>
-- <one-line reason for failure 2>
+Failed: K chunks.            ← "chunk" singular when K=1
+- <one-line reason per failure>
 …
 ```
-
-Use `chunk` (singular) when K=1, `chunks` (plural) otherwise.
-
----
-
-## Frontmatter schema
-
-Chunks use the note shape (`type: note`) per [§2 Frontmatter schema](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#2-frontmatter-schema-note--daily). No special braindump provenance or metadata — chunks are indistinguishable from `/note` captures once filed. This means `/note process` can triage them without any special handling.
 
 ---
 
 ## Examples
 
-**Inline text, multi-thought:**
+**Multi-thought:**
 ```
 user> /braindump I keep forgetting to check the lint score before PRs. Also need to revisit the hot cache size — it's been growing. And the daily skill confirmation message looks wrong in dark mode.
-# Split: 3 chunks (3 distinct observations)
 assistant>
 Captured 3 notes:
 - notes/2026-04-27-check-lint-score-before-prs.md
@@ -139,7 +103,6 @@ Captured 3 notes:
 **Single thought (no spurious split):**
 ```
 user> /braindump The slug truncation rule needs to account for multi-byte unicode characters — right now it can split in the middle of a grapheme cluster, which breaks vault filenames on some filesystems.
-# Split: 1 chunk (single atomic idea, just long)
 assistant>
 Captured 1 note:
 - notes/2026-04-27-slug-truncation-multibyte-unicode.md
@@ -148,33 +111,14 @@ Captured 1 note:
 **File input (vault-relative):**
 ```
 user> /braindump retro-notes/2026-04-feature-retro.txt
-# File resolved as <vault_root>/retro-notes/2026-04-feature-retro.txt
-# Contents split into N chunks
+# resolved as <vault_root>/retro-notes/2026-04-feature-retro.txt
 assistant>
 Captured N notes:
 - notes/2026-04-27-…
 …
 ```
 
-**No vault:**
-```
-user> /braindump some thoughts
-assistant> No vault configured — run /wiki init first.
-```
-
-**Empty body:**
-```
-user> /braindump
-assistant> /braindump requires text or a file path.
-```
-
-**Binary file:**
-```
-user> /braindump _attachments/diagram.png
-assistant> Binary inputs not supported in /braindump — wait for sub-issue E (rich capture inputs).
-```
-
-**One chunk fails (filesystem error):**
+**One chunk fails:**
 ```
 assistant>
 Captured 2 notes:

--- a/skills/braindump/SKILL.md
+++ b/skills/braindump/SKILL.md
@@ -64,7 +64,7 @@ Pass the dump body to a **single LLM reasoning step** (think step, not a separat
 
 Output: an ordered list of chunks (strings). Each chunk is a verbatim excerpt from the original dump.
 
-**If split returns zero chunks** (LLM error, empty result, or the body is blank after parsing) → abort:
+**If split returns zero chunks** (unexpected empty result from the reasoning step, or the body is blank after parsing) → hard-abort immediately, no retry:
 ```
 /braindump split returned no chunks. Original text not captured.
 ```
@@ -98,7 +98,7 @@ Captured N notes:
 …
 ```
 
-Filenames in chunk order. No NEW/MATCH labels — silent routing principle. No diff. No reasoning.
+Use `note` (singular) when N=1, `notes` (plural) otherwise. Filenames in chunk order. No NEW/MATCH labels — silent routing principle. No diff. No reasoning.
 
 If any chunks failed (per AC-13):
 
@@ -107,8 +107,13 @@ Captured N notes:
 - notes/YYYY-MM-DD-<slug>.md
 …
 
-Failed: K chunks. <one-line reason per failure>
+Failed: K chunks.
+- <one-line reason for failure 1>
+- <one-line reason for failure 2>
+…
 ```
+
+Use `chunk` (singular) when K=1, `chunks` (plural) otherwise.
 
 ---
 
@@ -136,7 +141,7 @@ Captured 3 notes:
 user> /braindump The slug truncation rule needs to account for multi-byte unicode characters — right now it can split in the middle of a grapheme cluster, which breaks vault filenames on some filesystems.
 # Split: 1 chunk (single atomic idea, just long)
 assistant>
-Captured 1 notes:
+Captured 1 note:
 - notes/2026-04-27-slug-truncation-multibyte-unicode.md
 ```
 
@@ -176,5 +181,6 @@ Captured 2 notes:
 - notes/2026-04-27-check-lint-score-before-prs.md
 - notes/2026-04-27-daily-skill-confirmation-dark-mode.md
 
-Failed: 1 chunks. notes/: permission denied writing 2026-04-27-hot-cache-size-growing.md
+Failed: 1 chunk.
+- notes/: permission denied writing 2026-04-27-hot-cache-size-growing.md
 ```


### PR DESCRIPTION
## Summary

- Adds `skills/braindump/SKILL.md`: accepts inline text or a vault-relative/absolute file path, splits the dump into atomic thoughts via a single LLM reasoning step, and runs each chunk through the full CAPTURE pipeline (MATCH/NEW + index patch per `_shared/capture-pipeline.md` §1–4, §6)
- Chunks land in `notes/` as standard `type: note` records with no braindump provenance — fully triageable by `/note process`
- Updates `CLAUDE.md` and `README.md` skills tables with trigger phrases

Closes #63

## Manual testing

1. **No vault configured** — run `/braindump some thoughts` without `vault_path` set → should abort with `No vault configured — run /wiki init first.`
2. **Empty body** — run `/braindump` with no argument → should abort with `/braindump requires text or a file path.`
3. **Inline multi-thought** — run `/braindump` with 3+ distinct observations in one message → confirm split produces one note per observation, output lists `Captured N notes:` with N filenames, no NEW/MATCH labels
4. **Single thought (no spurious split)** — run `/braindump` with one long but unified idea → confirm exactly one note produced, output reads `Captured 1 note:`
5. **File input** — create a `.txt` file under `<vault_root>`, run `/braindump <relative-path>` → confirm file contents are split and captured
6. **Binary file** — run `/braindump _attachments/some.png` → should abort with `Binary inputs not supported in /braindump — wait for sub-issue E (rich capture inputs).`
7. **Post-capture triage** — after a braindump, run `/note process` → confirm each chunk appears as a regular pending note with no special metadata
8. **MATCH across chunks** — braindump two closely related observations → confirm chunk 2 can MATCH-append to the note created by chunk 1 in the same call