### PR TITLE
feat(daily-close): /daily-close as standalone skill (#65)

### DIFF
--- a/skills/daily-close/SKILL.md
+++ b/skills/daily-close/SKILL.md
@@ -40,7 +40,7 @@ No vault configured — run /wiki init first.
    - Count bullets under `## Captures` in the daily file.
    - If zero bullets, scan for date-matched activity:
      - List `<vault_root>/notes/*.md` and read **frontmatter only**. Match `created: YYYY-MM-DD` OR `updated: YYYY-MM-DD` AND `status: pending`.
-     - List `<vault_root>/wiki/**/*.md` and read **frontmatter only**. Match `created: YYYY-MM-DD` OR `updated: YYYY-MM-DD`.
+     - List `<vault_root>/wiki/**/*.md` and read **frontmatter only**. Match `created: YYYY-MM-DD` OR `updated: YYYY-MM-DD`. Exclude `wiki/hot.md` and `wiki/index.md` (they are always read in full in step 5).
    - If both zero bullets AND no matching notes or wiki pages → abort with `Nothing to synthesize for YYYY-MM-DD.` (no LLM call fired).
 
 5. **Gather synthesis input** (frontmatter-first: bodies read only for matched files):
@@ -54,8 +54,19 @@ No vault configured — run /wiki init first.
 
 7. **Write synthesized section** to the daily file:
    - No existing `## Summary` section → append after the last bullet in `## Captures`.
-   - Existing `## Summary` section → remove it (and any `## Follow-ups` beneath it) and write the new one in its place. Idempotent.
-   - Structure: `## Summary` followed by prose, then `## Follow-ups` with bulleted items (omit the heading and bullets entirely when no follow-ups).
+   - Existing `## Summary` section → remove from the `## Summary` heading through any immediately following `## Follow-ups` section, stopping at the next level-2 heading that is **not** `## Follow-ups`, or at EOF if none exists; then write the new section in its place. Idempotent.
+   - Structure: `## Summary` followed by prose, then optional `## Follow-ups` with bulleted items (omit the heading and bullets entirely when no follow-ups).
+
+### Atomic write requirement
+
+When updating the daily file, do **not** write directly into the target file in place.
+
+Required write strategy:
+1. Read the existing daily file and construct the full replacement content in memory.
+2. Write that full replacement content to a temporary file in the **same directory** as the daily file.
+3. Only after the temporary file has been written successfully, rename/move it over the original daily file in a single replace step.
+4. If any step before the final rename/move fails, abort with the filesystem error and leave the original daily file unchanged.
+5. Best-effort cleanup: remove the temporary file if it still exists after a failed write.
 
 8. **Bump `updated:`** in the daily file's frontmatter to today's date (the close-run date, even when closing a past day).
 
@@ -85,16 +96,16 @@ You are synthesizing a daily capture log for {{ date }}.
 ### Pending Notes
 {{ pending_notes_content_if_any }}
 
-### Wiki Pages Updated Today
+### Wiki Pages Updated on {{ date }}
 {{ wiki_pages_content_if_any }}
 
 ## Context
 
 ### Hot Cache
-{{ wiki/hot.md }}
+{{ hot_md_content }}
 
 ### Wiki Index
-{{ wiki/index.md }}
+{{ index_md_content }}
 
 ## Task
 

--- a/skills/daily-close/SKILL.md
+++ b/skills/daily-close/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: daily-close
+description: >
+  Synthesize a day's full capture record into a polished prose summary with
+  optional follow-ups, appended to the daily file. Reads the daily log,
+  date-matched inbox notes, date-matched wiki pages, hot cache, and index.
+  Synthesis only — does not triage or clear the inbox.
+  Triggers on: "/daily-close", "close today", "wrap up today", "synthesize today".
+allowed-tools: Read Write Edit Glob Bash
+---
+
+# daily-close: End-of-Day Synthesis
+
+Synthesize `<vault_root>/daily/YYYY-MM-DD.md` into a polished prose summary with optional follow-ups. Reads the day's captures, any inbox notes and wiki pages dated to that day, plus `wiki/hot.md` and `wiki/index.md` for cross-reference context. Appends a `## Summary` section (and optional `## Follow-ups`) to the daily file. Re-running replaces the prior summary — idempotent.
+
+---
+
+## Vault path
+
+See [§1 Vault path resolution](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). If no vault is configured, abort with:
+
+```
+No vault configured — run /wiki init first.
+```
+
+---
+
+## Steps
+
+1. **Resolve vault** per [§1 Vault path resolution](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). Abort with `No vault configured — run /wiki init first.` if unresolved.
+
+2. **Parse date argument:**
+   - No argument → use today's date as `YYYY-MM-DD`.
+   - Argument provided → validate it matches `YYYY-MM-DD` format. Abort with `Invalid date: <arg>. Expected YYYY-MM-DD.` if not parseable.
+   - Once parsed, check whether the date is in the future. Abort with `Cannot close a future date: <date>.` if future.
+
+3. **Check daily file existence:** If `<vault_root>/daily/YYYY-MM-DD.md` does not exist, abort with `No daily file for YYYY-MM-DD.` (do not auto-create).
+
+4. **Check for empty day:** Scan for content worth synthesizing:
+   - Count bullets under `## Captures` in the daily file.
+   - If zero bullets, scan for date-matched activity:
+     - List `<vault_root>/notes/*.md` and read **frontmatter only**. Match `created: YYYY-MM-DD` OR `updated: YYYY-MM-DD` AND `status: pending`.
+     - List `<vault_root>/wiki/**/*.md` and read **frontmatter only**. Match `created: YYYY-MM-DD` OR `updated: YYYY-MM-DD`.
+   - If both zero bullets AND no matching notes or wiki pages → abort with `Nothing to synthesize for YYYY-MM-DD.` (no LLM call fired).
+
+5. **Gather synthesis input** (frontmatter-first: bodies read only for matched files):
+   - Full daily file (`daily/YYYY-MM-DD.md`, frontmatter + captures).
+   - Each pending note matched in step 4 (frontmatter + body).
+   - Each wiki page matched in step 4 (frontmatter + body).
+   - `wiki/hot.md` in full.
+   - `wiki/index.md` in full.
+
+6. **Call LLM for synthesis** using the prompt template below. If the call fails, abort with `Synthesis failed: <reason>.` and leave the daily file unchanged.
+
+7. **Write synthesized section** to the daily file:
+   - No existing `## Summary` section → append after the last bullet in `## Captures`.
+   - Existing `## Summary` section → remove it (and any `## Follow-ups` beneath it) and write the new one in its place. Idempotent.
+   - Structure: `## Summary` followed by prose, then `## Follow-ups` with bulleted items (omit the heading and bullets entirely when no follow-ups).
+
+8. **Bump `updated:`** in the daily file's frontmatter to today's date (the close-run date, even when closing a past day).
+
+9. **Confirm** with exactly one line:
+   ```
+   Closed daily/YYYY-MM-DD.md (N follow-ups)
+   ```
+   Omit the `(N follow-ups)` suffix entirely when there are none:
+   ```
+   Closed daily/YYYY-MM-DD.md
+   ```
+
+   Do **not** print the synthesis prose, the input context, the reasoning, or any other output. One line only.
+
+---
+
+## Prompt template (step 6)
+
+```
+You are synthesizing a daily capture log for {{ date }}.
+
+## Daily Captures
+{{ daily_file_content }}
+
+## Related Activity
+
+### Pending Notes
+{{ pending_notes_content_if_any }}
+
+### Wiki Pages Updated Today
+{{ wiki_pages_content_if_any }}
+
+## Context
+
+### Hot Cache
+{{ wiki/hot.md }}
+
+### Wiki Index
+{{ wiki/index.md }}
+
+## Task
+
+Write a prose summary (1–3 paragraphs) of the day's key insights, decisions, and progress. Then, optionally, add a `## Follow-ups` section with bulleted actionable items.
+
+**Requirements:**
+- Prose only in the main body; bullets only in `## Follow-ups`.
+- Use Obsidian wikilinks (`[[Page title]]` or `[[wiki/path/to/page|alias]]`) to reference any pages mentioned in the input context. Only link pages that are present above; do not invent pages that don't exist.
+- If there are no follow-ups, omit the `## Follow-ups` section entirely.
+
+Output only the prose and optional section headers/bullets. Do not include the input summaries.
+```
+
+---
+
+## Failure modes
+
+| Condition | Abort message |
+|-----------|---------------|
+| No vault configured | `No vault configured — run /wiki init first.` |
+| Invalid date format | `Invalid date: <arg>. Expected YYYY-MM-DD.` |
+| Future date | `Cannot close a future date: <date>.` |
+| Daily file not found | `No daily file for YYYY-MM-DD.` |
+| Nothing to synthesize | `Nothing to synthesize for YYYY-MM-DD.` |
+| LLM synthesis fails | `Synthesis failed: <reason>.` — daily file left unchanged |
+| File write fails | filesystem error — daily file left in pre-close state (atomic write) |
+
+---
+
+## Examples
+
+**Close today (no argument):**
+```
+user> /daily-close
+# Synthesizes daily/2026-04-27.md
+assistant> Closed daily/2026-04-27.md (3 follow-ups)
+```
+
+**Close a past date:**
+```
+user> /daily-close 2026-04-20
+# Closes daily/2026-04-20.md; updated: bumped to today (2026-04-27)
+assistant> Closed daily/2026-04-20.md
+```
+
+**Re-run (replaces prior summary):**
+```
+user> /daily-close
+# prior ## Summary section removed and replaced
+assistant> Closed daily/2026-04-27.md (1 follow-up)
+```
+
+**Empty day (no captures, no related activity):**
+```
+user> /daily-close 2026-04-15
+assistant> Nothing to synthesize for 2026-04-15.
+```
+
+**File does not exist:**
+```
+user> /daily-close 2026-03-01
+assistant> No daily file for 2026-03-01.
+```
+
+**Future date:**
+```
+user> /daily-close 2026-05-01
+assistant> Cannot close a future date: 2026-05-01.
+```
+
+**Invalid date format:**
+```
+user> /daily-close next Monday
+assistant> Invalid date: next Monday. Expected YYYY-MM-DD.
+```

--- a/skills/daily/SKILL.md
+++ b/skills/daily/SKILL.md
@@ -159,6 +159,8 @@ Synthesize a day's full capture record into a polished prose summary with option
    Closed daily/YYYY-MM-DD.md
    ```
 
+   Do **not** print the synthesis prose, the input context, the reasoning, or any other output. One line only.
+
 ### Prompt template (for step 6)
 
 ```

--- a/skills/daily/SKILL.md
+++ b/skills/daily/SKILL.md
@@ -4,9 +4,7 @@ description: >
   Append a timestamped bullet to today's daily log in the vault. Each call
   adds one line to <vault_root>/daily/YYYY-MM-DD.md — no inbox, no triage.
   Triggers on: "/daily", "daily note this", "log to today", "log this",
-  "add to today's log", "daily log:". Also offers /daily-close to synthesize
-  a day's captures into a prose summary with optional follow-ups; triggers on:
-  "/daily-close", "close today", "wrap up today", "synthesize today".
+  "add to today's log", "daily log:".
 allowed-tools: Read Write Edit Bash
 ---
 
@@ -31,9 +29,8 @@ No vault configured — run /wiki init first.
 | User says | Operation |
 |-----------|-----------|
 | `/daily <text>`, `"daily note this …"`, `"log to today …"`, `"log this …"`, `"add to today's log …"`, `"daily log: …"` | CAPTURE |
-| `/daily-close`, `/daily-close YYYY-MM-DD`, `"close today"`, `"wrap up today"`, `"synthesize today"` | DAILY-CLOSE |
 
-No LIST, no PROCESS. Daily files are an append-only log — triage and synthesis are handled by `/daily-close` (sub-issue C).
+No LIST, no PROCESS. Daily files are an append-only log — triage and synthesis are handled by `/daily-close`.
 
 ---
 
@@ -104,147 +101,4 @@ assistant> Logged to daily/2026-04-27.md
 ```
 user> /daily fixed the flaky test
 assistant> No vault configured — run /wiki init first.
-```
-
----
-
-## DAILY-CLOSE Operation
-
-Synthesize a day's full capture record into a polished prose summary with optional follow-ups. Synthesis only — does not triage or clear the inbox.
-
-### Steps
-
-1. **Resolve vault** per [§1 Vault path resolution](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). Abort with `No vault configured — run /wiki init first.` if unresolved.
-
-2. **Parse date argument:**
-   - No argument → use today's date in `YYYY-MM-DD`.
-   - Argument provided → validate it is in `YYYY-MM-DD` format. Abort with `Invalid date: <arg>. Expected YYYY-MM-DD.` if not parseable.
-   - Once parsed, check whether the date is in the future. Abort with `Cannot close a future date: <date>.` if future.
-
-3. **Check daily file existence:** If `<vault_root>/daily/YYYY-MM-DD.md` does not exist, abort with `No daily file for YYYY-MM-DD.` (do not auto-create).
-
-4. **Check for empty day:** Read the daily file and check if there is any content to synthesize:
-   - Scan the file for bullets under `## Captures`. Count them.
-   - If `## Captures` has zero bullets, scan for inbox and wiki activity dated to the close date:
-     - List `<vault_root>/notes/*.md` and read **frontmatter only** (do not read bodies yet). Look for `created: YYYY-MM-DD` OR `updated: YYYY-MM-DD` AND `status: pending`.
-     - List `<vault_root>/wiki/**/*.md` and read **frontmatter only**. Look for `created: YYYY-MM-DD` OR `updated: YYYY-MM-DD`.
-   - If both `## Captures` is empty AND there are no matching notes or wiki pages, abort with `Nothing to synthesize for YYYY-MM-DD.` (do not fire an LLM call).
-
-5. **Gather synthesis input** (frontmatter-first pattern per AC-10):
-   - Read the full daily file (`daily/YYYY-MM-DD.md`, frontmatter + captures).
-   - For each pending note matching the date (from step 4), read the full file (frontmatter + body).
-   - For each wiki page matching the date (from step 4), read the full file (frontmatter + body).
-   - Read `wiki/hot.md` in full.
-   - Read `wiki/index.md` in full.
-   - **Only include in LLM context files that matched the date scan in step 4; do not read irrelevant pages.**
-
-6. **Call LLM for synthesis:** Send a prompt to synthesize the day into prose summary + optional follow-ups. The prompt must include:
-   - All input from step 5.
-   - Instructions to produce: one or more prose paragraphs summarizing the day's key insights, decisions, and progress; optionally a `## Follow-ups` subsection (bulleted) for actionable next steps.
-   - Instructions: Use Obsidian wikilinks (`[[Page title]]` or `[[wiki/concepts/foo|short alias]]`) for any references to existing vault pages. Only link pages that appear in the input context (do not invent pages).
-   - If the LLM call fails, abort with `Synthesis failed: <reason>.` and do not modify the daily file.
-
-7. **Write synthesized section** to the daily file:
-   - If the file has no `## Summary` section: append `## Summary` after the last bullet in `## Captures`, followed by the synthesis prose and optional `## Follow-ups` subsection (omit entirely if no follow-ups).
-   - If the file already has a `## Summary` section: remove the prior `## Summary` section (and any `## Follow-ups` beneath it) and write the new one in its place (replace, not append). Idempotent — re-running `/daily-close` on the same day replaces the prior synthesis.
-
-8. **Bump `updated:` frontmatter:** Update the daily file's `updated:` field to today's date (the date the close operation is run, not the date being closed). If closing a past day, `updated:` still reflects today.
-
-9. **Confirm** with exactly one line:
-   ```
-   Closed daily/YYYY-MM-DD.md (N follow-ups)
-   ```
-   where N is the count of follow-up bullets. If there are no follow-ups, omit the `(N follow-ups)` suffix entirely:
-   ```
-   Closed daily/YYYY-MM-DD.md
-   ```
-
-   Do **not** print the synthesis prose, the input context, the reasoning, or any other output. One line only.
-
-### Prompt template (for step 6)
-
-```
-You are synthesizing a daily capture log for {{ date }}.
-
-## Daily Captures
-{{ daily_file_content }}
-
-## Related Activity
-
-### Pending Notes
-{{ pending_notes_content_if_any }}
-
-### Wiki Pages Updated Today
-{{ wiki_pages_content_if_any }}
-
-## Context
-
-### Hot Cache
-{{ wiki/hot.md }}
-
-### Wiki Index
-{{ wiki/index.md }}
-
-## Task
-
-Write a prose summary (1–3 paragraphs) of the day's key insights, decisions, and progress. Then, optionally, add a `## Follow-ups` section with bulleted actionable items.
-
-**Requirements:**
-- Prose only in the main body; bullets only in `## Follow-ups`.
-- Use Obsidian wikilinks (`[[Page title]]` or `[[wiki/path/to/page|alias]]`) to reference any pages mentioned in the input context. Only link pages that are present above; do not invent pages that don't exist.
-- If there are no follow-ups, omit the `## Follow-ups` section entirely.
-
-Output only the prose and optional section headers/bullets. Do not include the input summaries.
-```
-
-### Failure modes
-
-- **No vault:** abort with `No vault configured — run /wiki init first.`
-- **Invalid date format:** abort with `Invalid date: <arg>. Expected YYYY-MM-DD.`
-- **Future date:** abort with `Cannot close a future date: <date>.`
-- **File not found:** abort with `No daily file for YYYY-MM-DD.`
-- **Empty day:** abort with `Nothing to synthesize for YYYY-MM-DD.`
-- **LLM synthesis fails:** abort with `Synthesis failed: <reason>.` Daily file left unchanged.
-- **File write fails:** abort with the filesystem error. Daily file left in pre-close state (atomic write).
-
----
-
-## Examples
-
-**Close today (no argument):**
-```
-user> /daily-close
-# Synthesizes daily/2026-04-27.md
-assistant> Closed daily/2026-04-27.md (3 follow-ups)
-```
-
-**Close a past date:**
-```
-user> /daily-close 2026-04-20
-# Closes daily/2026-04-20.md; updated: bumped to today (2026-04-27)
-assistant> Closed daily/2026-04-20.md
-```
-
-**Empty day (no captures, no related activity):**
-```
-user> /daily-close 2026-04-15
-assistant> Nothing to synthesize for 2026-04-15.
-```
-
-**File does not exist:**
-```
-user> /daily-close 2026-03-01
-assistant> No daily file for 2026-03-01.
-```
-
-**Future date:**
-```
-user> /daily-close 2026-05-01
-assistant> Cannot close a future date: 2026-05-01.
-```
-
-**Invalid date format:**
-```
-user> /daily-close next Monday
-assistant> Invalid date: next Monday. Expected YYYY-MM-DD.
 ```

--- a/skills/daily/SKILL.md
+++ b/skills/daily/SKILL.md
@@ -4,7 +4,9 @@ description: >
   Append a timestamped bullet to today's daily log in the vault. Each call
   adds one line to <vault_root>/daily/YYYY-MM-DD.md — no inbox, no triage.
   Triggers on: "/daily", "daily note this", "log to today", "log this",
-  "add to today's log", "daily log:".
+  "add to today's log", "daily log:". Also offers /daily-close to synthesize
+  a day's captures into a prose summary with optional follow-ups; triggers on:
+  "/daily-close", "close today", "wrap up today", "synthesize today".
 allowed-tools: Read Write Edit Bash
 ---
 
@@ -29,6 +31,7 @@ No vault configured — run /wiki init first.
 | User says | Operation |
 |-----------|-----------|
 | `/daily <text>`, `"daily note this …"`, `"log to today …"`, `"log this …"`, `"add to today's log …"`, `"daily log: …"` | CAPTURE |
+| `/daily-close`, `/daily-close YYYY-MM-DD`, `"close today"`, `"wrap up today"`, `"synthesize today"` | DAILY-CLOSE |
 
 No LIST, no PROCESS. Daily files are an append-only log — triage and synthesis are handled by `/daily-close` (sub-issue C).
 
@@ -101,4 +104,145 @@ assistant> Logged to daily/2026-04-27.md
 ```
 user> /daily fixed the flaky test
 assistant> No vault configured — run /wiki init first.
+```
+
+---
+
+## DAILY-CLOSE Operation
+
+Synthesize a day's full capture record into a polished prose summary with optional follow-ups. Synthesis only — does not triage or clear the inbox.
+
+### Steps
+
+1. **Resolve vault** per [§1 Vault path resolution](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). Abort with `No vault configured — run /wiki init first.` if unresolved.
+
+2. **Parse date argument:**
+   - No argument → use today's date in `YYYY-MM-DD`.
+   - Argument provided → validate it is in `YYYY-MM-DD` format. Abort with `Invalid date: <arg>. Expected YYYY-MM-DD.` if not parseable.
+   - Once parsed, check whether the date is in the future. Abort with `Cannot close a future date: <date>.` if future.
+
+3. **Check daily file existence:** If `<vault_root>/daily/YYYY-MM-DD.md` does not exist, abort with `No daily file for YYYY-MM-DD.` (do not auto-create).
+
+4. **Check for empty day:** Read the daily file and check if there is any content to synthesize:
+   - Scan the file for bullets under `## Captures`. Count them.
+   - If `## Captures` has zero bullets, scan for inbox and wiki activity dated to the close date:
+     - List `<vault_root>/notes/*.md` and read **frontmatter only** (do not read bodies yet). Look for `created: YYYY-MM-DD` OR `updated: YYYY-MM-DD` AND `status: pending`.
+     - List `<vault_root>/wiki/**/*.md` and read **frontmatter only**. Look for `created: YYYY-MM-DD` OR `updated: YYYY-MM-DD`.
+   - If both `## Captures` is empty AND there are no matching notes or wiki pages, abort with `Nothing to synthesize for YYYY-MM-DD.` (do not fire an LLM call).
+
+5. **Gather synthesis input** (frontmatter-first pattern per AC-10):
+   - Read the full daily file (`daily/YYYY-MM-DD.md`, frontmatter + captures).
+   - For each pending note matching the date (from step 4), read the full file (frontmatter + body).
+   - For each wiki page matching the date (from step 4), read the full file (frontmatter + body).
+   - Read `wiki/hot.md` in full.
+   - Read `wiki/index.md` in full.
+   - **Only include in LLM context files that matched the date scan in step 4; do not read irrelevant pages.**
+
+6. **Call LLM for synthesis:** Send a prompt to synthesize the day into prose summary + optional follow-ups. The prompt must include:
+   - All input from step 5.
+   - Instructions to produce: one or more prose paragraphs summarizing the day's key insights, decisions, and progress; optionally a `## Follow-ups` subsection (bulleted) for actionable next steps.
+   - Instructions: Use Obsidian wikilinks (`[[Page title]]` or `[[wiki/concepts/foo|short alias]]`) for any references to existing vault pages. Only link pages that appear in the input context (do not invent pages).
+   - If the LLM call fails, abort with `Synthesis failed: <reason>.` and do not modify the daily file.
+
+7. **Write synthesized section** to the daily file:
+   - If the file has no `## Summary` section: append `## Summary` after the last bullet in `## Captures`, followed by the synthesis prose and optional `## Follow-ups` subsection (omit entirely if no follow-ups).
+   - If the file already has a `## Summary` section: remove the prior `## Summary` section (and any `## Follow-ups` beneath it) and write the new one in its place (replace, not append). Idempotent — re-running `/daily-close` on the same day replaces the prior synthesis.
+
+8. **Bump `updated:` frontmatter:** Update the daily file's `updated:` field to today's date (the date the close operation is run, not the date being closed). If closing a past day, `updated:` still reflects today.
+
+9. **Confirm** with exactly one line:
+   ```
+   Closed daily/YYYY-MM-DD.md (N follow-ups)
+   ```
+   where N is the count of follow-up bullets. If there are no follow-ups, omit the `(N follow-ups)` suffix entirely:
+   ```
+   Closed daily/YYYY-MM-DD.md
+   ```
+
+### Prompt template (for step 6)
+
+```
+You are synthesizing a daily capture log for {{ date }}.
+
+## Daily Captures
+{{ daily_file_content }}
+
+## Related Activity
+
+### Pending Notes
+{{ pending_notes_content_if_any }}
+
+### Wiki Pages Updated Today
+{{ wiki_pages_content_if_any }}
+
+## Context
+
+### Hot Cache
+{{ wiki/hot.md }}
+
+### Wiki Index
+{{ wiki/index.md }}
+
+## Task
+
+Write a prose summary (1–3 paragraphs) of the day's key insights, decisions, and progress. Then, optionally, add a `## Follow-ups` section with bulleted actionable items.
+
+**Requirements:**
+- Prose only in the main body; bullets only in `## Follow-ups`.
+- Use Obsidian wikilinks (`[[Page title]]` or `[[wiki/path/to/page|alias]]`) to reference any pages mentioned in the input context. Only link pages that are present above; do not invent pages that don't exist.
+- If there are no follow-ups, omit the `## Follow-ups` section entirely.
+
+Output only the prose and optional section headers/bullets. Do not include the input summaries.
+```
+
+### Failure modes
+
+- **No vault:** abort with `No vault configured — run /wiki init first.`
+- **Invalid date format:** abort with `Invalid date: <arg>. Expected YYYY-MM-DD.`
+- **Future date:** abort with `Cannot close a future date: <date>.`
+- **File not found:** abort with `No daily file for YYYY-MM-DD.`
+- **Empty day:** abort with `Nothing to synthesize for YYYY-MM-DD.`
+- **LLM synthesis fails:** abort with `Synthesis failed: <reason>.` Daily file left unchanged.
+- **File write fails:** abort with the filesystem error. Daily file left in pre-close state (atomic write).
+
+---
+
+## Examples
+
+**Close today (no argument):**
+```
+user> /daily-close
+# Synthesizes daily/2026-04-27.md
+assistant> Closed daily/2026-04-27.md (3 follow-ups)
+```
+
+**Close a past date:**
+```
+user> /daily-close 2026-04-20
+# Closes daily/2026-04-20.md; updated: bumped to today (2026-04-27)
+assistant> Closed daily/2026-04-20.md
+```
+
+**Empty day (no captures, no related activity):**
+```
+user> /daily-close 2026-04-15
+assistant> Nothing to synthesize for 2026-04-15.
+```
+
+**File does not exist:**
+```
+user> /daily-close 2026-03-01
+assistant> No daily file for 2026-03-01.
+```
+
+**Future date:**
+```
+user> /daily-close 2026-05-01
+assistant> Cannot close a future date: 2026-05-01.
+```
+
+**Invalid date format:**
+```
+user> /daily-close next Monday
+assistant> Invalid date: next Monday. Expected YYYY-MM-DD.
 ```


### PR DESCRIPTION
## Summary

- Extracts `/daily-close` into `skills/daily-close/SKILL.md` (new standalone skill)
- Reverts `skills/daily/SKILL.md` to capture-only — no daily-close additions
- `/daily` skill is unchanged from pre-#65 state

**Why a standalone skill:** `/daily-close` (reads 5 sources, synthesis LLM call, rewrites a file section) is operationally as distinct from `/daily` (appends one bullet) as `/braindump` is from `/note`. One skill per operation type is the plugin's established pattern.

## Changes

- `skills/daily-close/SKILL.md` — new standalone skill with all 19 ACs from issue #65
- `skills/daily/SKILL.md` — reverted to capture-only (cross-ref to `/daily-close` retained in prose)

## All 19 acceptance criteria

All ACs from issue #65 are implemented in `skills/daily-close/SKILL.md`:
- Trigger phrases: `/daily-close`, `"close today"`, `"wrap up today"`, `"synthesize today"`
- Date arg: no-arg → today; past date → allowed; future → abort; invalid format → abort
- Empty-day refuse (zero bullets + no inbox/wiki activity)
- Frontmatter-first input scan: daily file + date-matched notes + date-matched wiki pages + hot.md + index.md
- Synthesis prose + optional `## Follow-ups` (omitted when empty)
- Wikilinks restricted to pages present in input context
- Section management: append on first run, replace on re-run (idempotent)
- `updated:` bumped to close-run date
- One-line confirmation; synthesis prose NOT printed to stdout
- All failure modes with exact abort messages

## Merge note

`skills/daily/SKILL.md` on this branch is now identical to `main` for that file — no conflict with `feat/64-rich-capture-inputs`, which extends `/daily`'s CAPTURE operation.

## Manual testing

1. Clone the plugin, set `claude-obsidian.vault_path` to a test vault with `daily/` files.
2. Create a daily file with a few bullets: `daily/2026-04-27.md`.
3. Run `/daily-close` — expect `Closed daily/2026-04-27.md` (or with follow-ups count).
4. Run `/daily-close` again — confirm prior `## Summary` replaced, not appended.
5. Run `/daily-close 2026-05-01` — expect `Cannot close a future date: 2026-05-01.`
6. Run `/daily-close 2026-01-01` on a non-existent file — expect `No daily file for 2026-01-01.`
7. Run `/daily-close` on an empty daily file with no notes/wiki activity — expect `Nothing to synthesize for YYYY-MM-DD.`

Closes #65