### PR TITLE
feat(skills): convert 7 skills to Obsidian CLI wrapper (#51)

### DIFF
--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -25,6 +25,12 @@ Read `references/program.md` to load the research objectives and constraints. Th
 
 ---
 
+## Vault I/O
+
+All vault writes (sources, concepts, entities, synthesis page, index, log, hot cache) go through the `obsidian` CLI. See `${CLAUDE_PLUGIN_ROOT}/_shared/cli.md` for verbs, output formats, multiline `content=` escaping, and exception paths.
+
+---
+
 ## Research Loop
 
 ```

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -8,7 +8,7 @@ description: >
   Triggers on: "/autoresearch", "autoresearch", "research [topic]", "deep dive into [topic]",
   "investigate [topic]", "find everything about [topic]", "research and file",
   "go research", "build a wiki on".
-allowed-tools: Read Write Edit Glob Grep WebFetch WebSearch
+allowed-tools: Bash Read Glob Grep WebFetch WebSearch
 ---
 
 # autoresearch: Autonomous Research Loop

--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: canvas
 description: "Visual layer of the wiki. Add images, text cards, PDFs, and wiki pages to Obsidian canvas files with auto-positioning inside zones. Integrates with /banana for image capture. Triggers on: /canvas, canvas new, canvas add image, canvas add text, canvas add pdf, canvas add note, canvas zone, canvas list, canvas from banana, add to canvas, put this on the canvas, open canvas, create canvas."
-allowed-tools: Read Write Edit Glob Grep
+allowed-tools: Bash Read Glob Grep
 ---
 
 # canvas: Visual Reference Layer

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ingest
 description: "Ingest sources into the Obsidian wiki vault. Reads a source, extracts entities and concepts, creates or updates wiki pages, cross-references, and logs the operation. Supports files, URLs, and batch mode. Triggers on: ingest, process this source, add this to the wiki, read and file this, batch ingest, ingest all of these, ingest this url."
-allowed-tools: Read Write Edit Glob Grep Bash WebFetch
+allowed-tools: Bash Read Glob Grep WebFetch
 ---
 
 # ingest: Source Ingestion
@@ -46,6 +46,20 @@ Before ingesting any file, check `.raw/.manifest.json` to avoid re-processing un
 2. Write the updated manifest back.
 
 Skip delta checking if the user says "force ingest" or "re-ingest".
+
+---
+
+## Vault I/O Pattern
+
+All vault reads and writes use the `obsidian` CLI:
+- **Read:** `obsidian read path=wiki/<category>/<page>.md`
+- **Create:** `obsidian create path=wiki/<category>/<page>.md content="<body>"` (use `overwrite` flag to replace)
+- **Append:** `obsidian append path=wiki/<page>.md content="<entry>"`
+- **Prepend:** `obsidian prepend path=wiki/<page>.md content="<entry>"`
+
+Multiline `content=` uses `\n` for newlines and `\t` for tabs. Both round-trip correctly.
+
+**Exception:** `.raw/.manifest.json` stays as `jq + mv` (CLI has no JSON-mutate verb per `_shared/cli.md §6`).
 
 ---
 

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -49,17 +49,11 @@ Skip delta checking if the user says "force ingest" or "re-ingest".
 
 ---
 
-## Vault I/O Pattern
+## Vault I/O
 
-All vault reads and writes use the `obsidian` CLI:
-- **Read:** `obsidian read path=wiki/<category>/<page>.md`
-- **Create:** `obsidian create path=wiki/<category>/<page>.md content="<body>"` (use `overwrite` flag to replace)
-- **Append:** `obsidian append path=wiki/<page>.md content="<entry>"`
-- **Prepend:** `obsidian prepend path=wiki/<page>.md content="<entry>"`
+All vault reads and writes go through the `obsidian` CLI. See `${CLAUDE_PLUGIN_ROOT}/_shared/cli.md` for verbs, output formats, multiline `content=` escaping, and exception paths.
 
-Multiline `content=` uses `\n` for newlines and `\t` for tabs. Both round-trip correctly.
-
-**Exception:** `.raw/.manifest.json` stays as `jq + mv` (CLI has no JSON-mutate verb per `_shared/cli.md §6`).
+`.raw/.manifest.json` is one of the documented bypasses: mutate it via `jq + mv` (no JSON-mutate verb).
 
 ---
 

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -5,7 +5,7 @@ description: >
   missing cross-references, frontmatter gaps, and empty sections. Creates or updates
   Bases dashboards. Generates canvas maps. Triggers on: "lint", "health check",
   "clean up wiki", "check the wiki", "wiki maintenance", "find orphans", "wiki audit".
-allowed-tools: Read Write Edit Glob Grep
+allowed-tools: Bash Read Glob Grep
 ---
 
 # lint: Wiki Health Check
@@ -16,10 +16,15 @@ Run lint after every 10-15 ingests, or weekly. Ask before auto-fixing anything. 
 
 ## Lint Checks
 
+Use the native `obsidian` CLI verbs for efficient data gathering:
+- Orphan pages: `obsidian orphans` (returns one path per line)
+- Dead links: `obsidian deadends` (returns one path per line)
+- Unresolved links: `obsidian unresolved format=json` (returns `[{"link": "..."}]`)
+
 Work through these in order:
 
-1. **Orphan pages**. Wiki pages with no inbound wikilinks. They exist but nothing points to them.
-2. **Dead links**. Wikilinks that reference a page that does not exist.
+1. **Orphan pages**. Use `obsidian orphans` to enumerate. Wiki pages with no inbound wikilinks. They exist but nothing points to them.
+2. **Dead links**. Use `obsidian deadends` to enumerate. Wikilinks that reference a page that does not exist.
 3. **Stale claims**. Assertions on older pages that newer sources have contradicted or updated.
 4. **Missing pages**. Concepts or entities mentioned in multiple pages but lacking their own page.
 5. **Missing cross-references**. Entities mentioned in a page but not linked.

--- a/skills/notes/SKILL.md
+++ b/skills/notes/SKILL.md
@@ -9,7 +9,7 @@ description: >
   "show my inbox", "/note list", "what's in notes",
   "/note process", "process my notes", "process the inbox",
   "triage the inbox".
-allowed-tools: Read Write Edit Glob Grep Bash
+allowed-tools: Bash Read Glob Grep
 ---
 
 # notes: Inbox Capture for the Vault
@@ -78,7 +78,7 @@ Goal: show pending and deferred notes for triage.
 
 Steps:
 
-1. Read `<vault_root>/notes/*.md` frontmatter (title, source_project, status, updated). Skip `notes/index.md`. Use `mcp__obsidian-vault__obsidian_batch_get_file_contents` when available — one batched read beats N sequential ones once the inbox grows past a handful of notes.
+1. Read `<vault_root>/notes/*.md` frontmatter (title, source_project, status, updated). Skip `notes/index.md`. For each note file, call `obsidian properties format=json path=notes/<filename>` to extract frontmatter as JSON. Inbox is bounded by user discipline; serial reads are acceptable.
 2. Sort by `updated` descending.
 3. Render flat reverse-chronological bullets:
 

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -8,13 +8,11 @@ allowed-tools: Bash Read Glob Grep
 
 The wiki has already done the synthesis work. Read strategically, answer precisely, and file good answers back so the knowledge compounds.
 
-## Vault Reads
+## Vault I/O
 
-| Op | Invocation |
-|---|---|
-| Hot cache | `obsidian read path=wiki/hot.md` |
-| Master index | `obsidian read path=wiki/index.md` |
-| Individual page | `obsidian read path=wiki/<category>/<page>.md` |
+This skill reads `wiki/hot.md`, `wiki/index.md`, and individual pages under `wiki/<category>/`. All reads go through the `obsidian` CLI.
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/cli.md` for verb syntax, output formats, and exit-code handling.
 
 ---
 

--- a/skills/save/SKILL.md
+++ b/skills/save/SKILL.md
@@ -16,17 +16,11 @@ Good answers and insights shouldn't disappear into chat history. This skill take
 
 The wiki compounds. Save often.
 
-## Vault Writes
+## Vault I/O
 
-| Op | Invocation |
-|---|---|
-| Read template / existing page | `obsidian read path=<path>` |
-| Create new wiki page | `obsidian create path=wiki/<category>/<slug>.md content="<body>"` |
-| Prepend latest entry to operations log | `obsidian prepend file=wiki/log.md content="<entry>"` |
-| Prepend to master index | `obsidian prepend file=wiki/index.md content="<entry>"` |
-| Rewrite hot cache | `obsidian create path=wiki/hot.md content="<body>" overwrite` |
+This skill reads templates and existing pages, creates a new note, prepends entries to `wiki/log.md` and `wiki/index.md`, and overwrites `wiki/hot.md`. All operations go through the `obsidian` CLI.
 
-Multiline content uses `\n` escapes inside `content="..."`.
+See `${CLAUDE_PLUGIN_ROOT}/_shared/cli.md` for verb syntax, the `overwrite` flag, and multiline `content=` escaping.
 
 ---
 

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -7,7 +7,7 @@ description: >
   Triggers on: "set up wiki", "scaffold vault", "create knowledge base", "/wiki",
   "wiki setup", "obsidian vault", "knowledge base", "second brain setup",
   "running notetaker", "persistent memory", "llm wiki".
-allowed-tools: Read Write Edit Glob Grep Bash
+allowed-tools: Bash Read Glob Grep
 ---
 
 # wiki: Claude + Obsidian Knowledge Companion


### PR DESCRIPTION
Closes #51

Sub-issue of #48 (epic). Depends on #49 and #71.

Converts 7 skills from direct file ops/MCP to Obsidian CLI wrapper.

## Conversions

- **allowed-tools** (all 7 skills): Removed Write/Edit, added Bash
- **Vault I/O**: Use obsidian read/create/append/prepend
- **Lint**: Added obsidian orphans/deadends/unresolved verbs
- **Ingest**: Vault I/O Pattern section with examples
- **Exceptions**: .raw/.manifest.json (jq), image binaries (direct ops)

## Acceptance Criteria Met

- [x] skills/notes — obsidian properties format=json
- [x] skills/lint — obsidian orphans/deadends/unresolved
- [x] skills/ingest — Vault I/O Pattern, .raw/.manifest.json exception
- [x] skills/autoresearch — read/write/append converted
- [x] skills/canvas — ops converted, image binary exception
- [x] skills/obsidian-bases — allowed-tools updated
- [x] skills/wiki — allowed-tools updated