### PR TITLE
MCP purge + v1.0.0 CHANGELOG + cli-setup examples (closes #53)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "claude-obsidian: Claude + Obsidian knowledge companion by Michał Konopski",
-    "version": "0.5.1"
+    "version": "1.0.0"
   },
   "plugins": [
     {
       "name": "claude-obsidian",
       "source": "./",
       "description": "Claude + Obsidian knowledge companion. Sets up a persistent, compounding wiki vault.",
-      "version": "0.5.1",
+      "version": "1.0.0",
       "author": {
         "name": "Michał Konopski",
         "url": "https://github.com/misiekhardcore"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-obsidian",
-  "version": "0.5.1",
+  "version": "1.0.0",
   "description": "Claude + Obsidian knowledge companion. Sets up a persistent, compounding wiki vault. Covers memory management, session notetaking, knowledge organization, and agent context across projects.",
   "author": {
     "name": "Michał Konopski",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,18 @@ Closes the CLI migration epic ([#48]). With this release, **all** vault I/O acro
 ### Changed
 
 - `_seed/FIRST_RUN.md` no longer instructs new users to install Local REST API or Tray. Templater remains the only required community plugin; CLI registration is the new third step ([#53]).
-- `_shared/capture-pipeline.md` bulk-frontmatter step now uses `obsidian properties format=json` instead of the MCP `batch_get_file_contents` fallback ([#53]).
+- `_shared/capture-pipeline.md` and `skills/notes/SKILL.md` now use `obsidian properties path=<file>` for frontmatter scans (the `properties` verb has no `format=json` support — fix references the empirical contract in `_shared/cli.md` §3) ([#53]).
 - `skills/wiki/references/cli-setup.md` Examples section is filled with end-to-end snippets for ingest, query, save, and the lint primitives surfaced by the CLI (`orphans`, `deadends`, `unresolved`, `backlinks`) ([#53]).
-- Plugin manifest bumped to `1.0.0` ([#53]).
+- `skills/daily/SKILL.md`, `skills/daily-close/SKILL.md`, `skills/braindump/SKILL.md`, and `skills/obsidian-bases/SKILL.md` now route every vault read and write through the `obsidian` CLI. `Write` and `Edit` are dropped from `allowed-tools`; atomic frontmatter rewrites use `obsidian create overwrite=true`; date-matched activity scans use `obsidian properties path=<file>` per candidate ([#53]).
+- `skills/obsidian-markdown/SKILL.md` `allowed-tools` trimmed to `Read` — this is a reference-text-only skill, never writes vault pages ([#53]).
+- `commands/wiki.md` SCAFFOLD step 3 no longer probes for an MCP server; it now checks vault registration via `obsidian list vaults` ([#53]).
+- `_shared/vault-structure.md` solution-page example renamed from `configure-mcp-server` to `register-vault-with-cli` ([#53]).
+- `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` bumped to `1.0.0` ([#53]).
+- `README.md` and `CLAUDE.md` skill listings now include `daily-close` (shipped in #69 but missed by both inventories) ([#53]).
+
+### Added
+
+- `commands/daily-close.md` and `commands/braindump.md` — slash-command stub files for `/daily-close` and `/braindump`. Both skills already advertised those triggers; without the command files they only auto-loaded via skill-description match and didn't appear in Claude Code's slash menu ([#53]).
 
 ### Migration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] — 2026-04-29
+
+Closes the CLI migration epic ([#48]). With this release, **all** vault I/O across every skill and hook routes through the Obsidian CLI; the Local REST API + MCP code path is gone.
+
+### Breaking Changes
+
+- **Obsidian 1.12.7+ is now a hard prerequisite.** The plugin no longer ships any non-CLI vault-access path. Sessions still start when Obsidian is closed (the SessionStart probe is fail-soft), but skills that touch the vault will error until Obsidian is running with the registered vault open.
+- **MCP server `obsidian-vault` is fully removed.** No skill, hook, script, or shared reference still calls `mcp__obsidian-vault__*`. Setup docs no longer mention the Local REST API community plugin, the Tray plugin, or the `NODE_TLS_REJECT_UNAUTHORIZED=0` workaround.
+- **For external plugin authors:** the `mcp__obsidian-vault__*` tool surface is gone in 1.0.0. Migrate to the `obsidian` CLI via Bash; see `_shared/cli.md` for the empirical contract (exit codes, output formats, escape-hatch policy) and `skills/wiki/references/cli-setup.md` for end-to-end examples ([#53]).
+
+### Changed
+
+- `_seed/FIRST_RUN.md` no longer instructs new users to install Local REST API or Tray. Templater remains the only required community plugin; CLI registration is the new third step ([#53]).
+- `_shared/capture-pipeline.md` bulk-frontmatter step now uses `obsidian properties format=json` instead of the MCP `batch_get_file_contents` fallback ([#53]).
+- `skills/wiki/references/cli-setup.md` Examples section is filled with end-to-end snippets for ingest, query, save, and the lint primitives surfaced by the CLI (`orphans`, `deadends`, `unresolved`, `backlinks`) ([#53]).
+- Plugin manifest bumped to `1.0.0` ([#53]).
+
+### Migration
+
+1. Confirm you are on Obsidian 1.12.7 or newer.
+2. If you skipped 0.5.0: register your vault with the CLI once — `obsidian register vault=/absolute/path/to/vault`.
+3. Optional cleanup of stale background state from older releases:
+   ```bash
+   pkill -f mcp-obsidian
+   ```
+   You can also disable or uninstall the Local REST API community plugin if nothing else on your machine uses it.
+4. No vault-side migrations required; existing wiki content is read/written unchanged.
+
+### Rollback
+
+If a regression blocks your work, pin the previous release:
+
+```bash
+/plugin install claude-obsidian@0.5.1
+```
+
+For a fully MCP-based rollback (no CLI dependency at all), pin `0.4.0`, re-enable the Local REST API community plugin, and follow the legacy `mcp-setup.md` (preserved in git history at the `v0.4.0` tag).
+
 ## [0.5.0] — 2026-04-26
 
 ### Breaking Changes
@@ -99,6 +137,7 @@ The 0.4.0 plugin re-enables the Local REST API + MCP code path. After pinning, y
 - `resolve-vault.sh` falls back to `settings.local.json` for out-of-session invocations where `${user_config.*}` is unavailable ([#33], [#32]).
 - Hooks pass `vault_path` as an argument to `resolve-vault.sh` ([#29]).
 
+[1.0.0]: https://github.com/misiekhardcore/claude-obsidian/releases/tag/v1.0.0
 [0.5.0]: https://github.com/misiekhardcore/claude-obsidian/releases/tag/v0.5.0
 [0.4.0]: https://github.com/misiekhardcore/claude-obsidian/releases/tag/v0.4.0
 [0.3.0]: https://github.com/misiekhardcore/claude-obsidian/releases/tag/v0.3.0
@@ -132,3 +171,5 @@ The 0.4.0 plugin re-enables the Local REST API + MCP code path. After pinning, y
 [#54]: https://github.com/misiekhardcore/claude-obsidian/pull/54
 [#57]: https://github.com/misiekhardcore/claude-obsidian/pull/57
 [#59]: https://github.com/misiekhardcore/claude-obsidian/pull/59
+[#48]: https://github.com/misiekhardcore/claude-obsidian/issues/48
+[#53]: https://github.com/misiekhardcore/claude-obsidian/issues/53

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ All skills live in `skills/<name>/SKILL.md` and are auto-discovered by Claude Co
 | `save` | `/save`, file this conversation, save insight |
 | `notes` | `/note`, `/dump`, note this, todo:, show my inbox, `/note process` |
 | `daily` | `/daily`, daily note this, log to today, log this, add to today's log |
+| `daily-close` | `/daily-close`, close today, wrap up today, synthesize today |
 | `braindump` | `/braindump`, brain dump this, dump the following thoughts, dump these thoughts, braindump:, split this into notes |
 | `autoresearch` | autoresearch, autonomous research loop |
 | `canvas` | `/canvas`, add to canvas, create canvas |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For detailed CLI setup (troubleshooting, Flatpak, sanity checks), see `skills/wi
 - `save` — save the current conversation or insight into the vault
 - `notes` — quick inbox capture (`/note`, `/dump`); list and process flows for triage
 - `daily` — append-only chronological log (`/daily`); timestamped bullets in `daily/YYYY-MM-DD.md`
+- `daily-close` — end-of-day synthesis (`/daily-close`, "close today", "wrap up today"); appends a polished `## Summary` to today's daily file, idempotent on re-run
 - `braindump` — split long-form text into atomic notes (`/braindump`, "brain dump this", "split this into notes"); each chunk filed via the full capture pipeline
 - `autoresearch` — autonomous iterative research loop
 - `canvas` — create / update Obsidian canvas files

--- a/_seed/FIRST_RUN.md
+++ b/_seed/FIRST_RUN.md
@@ -28,11 +28,14 @@ In **Settings → Community Plugins → Browse**, install:
 | Plugin | Purpose |
 |--------|---------|
 | **Templater** | Use the templates in `_templates/` to create new pages |
-| **Local REST API** | Exposes the vault so the `claude-obsidian` plugin can read and write pages |
-| **Tray** | Keeps Obsidian running in the system tray so the REST API stays available when the window is closed |
 
-After installing **Local REST API**, open its settings, copy the API key, and
-paste it into the `claude-obsidian` plugin settings so Claude can reach the vault.
+That's it for plugins. The `claude-obsidian` plugin reaches the vault through
+the **Obsidian CLI** (shipped with Obsidian 1.12.7+) — no community plugins,
+TLS bypasses, or API keys required. Just keep Obsidian running with this vault
+open while you work.
+
+See `skills/wiki/references/cli-setup.md` for the one-time CLI registration
+step (`obsidian register vault=...`) and a sanity check.
 
 ---
 

--- a/_shared/capture-pipeline.md
+++ b/_shared/capture-pipeline.md
@@ -96,7 +96,7 @@ Used by `/note` CAPTURE only. `/daily` is append-only (no MATCH/NEW — see §7)
 
 ### Enumeration
 
-List `<vault_root>/notes/*.md` and read **frontmatter only** for each (title, topic, tags). Skip bodies. Skip `notes/index.md` and any file with `status: deferred`. Cap at the **20 most recent by `updated:`**. Use `mcp__obsidian-vault__obsidian_batch_get_file_contents` when the MCP server is available.
+List `<vault_root>/notes/*.md` and read **frontmatter only** for each (title, topic, tags). Skip bodies. Skip `notes/index.md` and any file with `status: deferred`. Cap at the **20 most recent by `updated:`**. Use `obsidian properties format=json` for bulk frontmatter retrieval; fall back to per-file `obsidian read path=notes/<file>.md` only if `properties` is unavailable.
 
 ### Decision prompt
 

--- a/_shared/capture-pipeline.md
+++ b/_shared/capture-pipeline.md
@@ -96,7 +96,7 @@ Used by `/note` CAPTURE only. `/daily` is append-only (no MATCH/NEW — see §7)
 
 ### Enumeration
 
-List `<vault_root>/notes/*.md` and read **frontmatter only** for each (title, topic, tags). Skip bodies. Skip `notes/index.md` and any file with `status: deferred`. Cap at the **20 most recent by `updated:`**. Use `obsidian properties format=json` for bulk frontmatter retrieval; fall back to per-file `obsidian read path=notes/<file>.md` only if `properties` is unavailable.
+List `<vault_root>/notes/*.md` and read **frontmatter only** for each (title, topic, tags). Skip bodies. Skip `notes/index.md` and any file with `status: deferred`. Cap at the **20 most recent by `updated:`**. Use `obsidian properties path=notes/<file>` per candidate (returns the YAML frontmatter block as plain text — no `format=json` support; see `${CLAUDE_PLUGIN_ROOT}/_shared/cli.md` §3).
 
 ### Decision prompt
 

--- a/_shared/vault-structure.md
+++ b/_shared/vault-structure.md
@@ -13,7 +13,7 @@ Read this file when a skill needs to understand vault layout or interpret page m
 | `wiki/concepts/` | `concept` | Patterns, techniques, ideas, how-things-work explanations | Title Case or kebab-case slug; no "the" prefix |
 | `wiki/entities/` | `entity` | Named real-world things: people, tools, products, orgs, repos | Proper noun as named in the source |
 | `wiki/sources/` | `source` | One page per ingested source — metadata, key findings, links to derived pages | `<slug>` matching the `.raw/` filename |
-| `wiki/solutions/` | `solution` | Concrete recipes: how to accomplish a specific task end-to-end | Verb phrase, e.g. `configure-mcp-server` |
+| `wiki/solutions/` | `solution` | Concrete recipes: how to accomplish a specific task end-to-end | Verb phrase, e.g. `register-vault-with-cli` |
 | `wiki/comparisons/` | `comparison` | Side-by-side analysis of 2+ alternatives | `<A>-vs-<B>` or `comparing-<topic>` |
 | `wiki/questions/` | `question` | Open questions; closed questions link to the answer | Question as written, e.g. `why-tokens-compound` |
 | `wiki/domains/` | `domain` | Top-level topic groupings; each domain has its own `_index.md` and may contain sub-directories | kebab-case domain name, e.g. `machine-learning` |
@@ -23,7 +23,7 @@ Read this file when a skill needs to understand vault layout or interpret page m
 - `wiki/concepts/LLM Wiki Pattern.md` — a technique (concept)
 - `wiki/entities/Andrej Karpathy.md` — a person (entity)
 - `wiki/sources/llm-wiki-karpathy-gist.md` — the ingest record for a specific source
-- `wiki/solutions/configure-mcp-server.md` — step-by-step recipe (solution)
+- `wiki/solutions/register-vault-with-cli.md` — step-by-step recipe (solution)
 
 ---
 

--- a/commands/braindump.md
+++ b/commands/braindump.md
@@ -1,0 +1,8 @@
+---
+description: Split long-form text into atomic notes and file each via the capture pipeline. Triage later with /note process.
+argument-hint: "<text or file path>"
+---
+
+Read the `braindump` skill. Then run the SPLIT-then-CAPTURE flow with the argument(s) — either inline text, a vault-relative or absolute file path, or a supported image path. Each atomic chunk is filed through the standard `/note` CAPTURE pipeline (MATCH/NEW per chunk).
+
+If the argument is empty, surface: `Usage: /braindump <text or file path>`. If no vault is configured, surface: `No vault configured — run /wiki init first.`

--- a/commands/daily-close.md
+++ b/commands/daily-close.md
@@ -1,0 +1,8 @@
+---
+description: Synthesize today's daily log into a prose summary with optional follow-ups. Idempotent on re-run.
+argument-hint: "[YYYY-MM-DD]"
+---
+
+Read the `daily-close` skill. Then run the synthesis flow against today's daily file (`<vault_root>/daily/YYYY-MM-DD.md`), or against the date supplied as the argument if present. Reads the day's captures, date-matched inbox notes and wiki pages, plus `wiki/hot.md` and `wiki/index.md` for cross-reference context. Appends or replaces `## Summary` (and optionally `## Follow-ups`) on the daily file.
+
+If no vault is configured, surface: `No vault configured — run /wiki init first.` If the daily file does not exist for the target date, surface: `No daily file for <date> — nothing to close.`

--- a/commands/wiki.md
+++ b/commands/wiki.md
@@ -27,9 +27,9 @@ Surface the script's stdout to the user verbatim.
 
 ## SCAFFOLD (default)
 
-1. Check if Obsidian is installed. If not, offer to install it (see `skills/wiki/references/plugins.md`).
+1. Check if Obsidian is installed (1.12.7+). If not, offer to install it (see `skills/wiki/references/plugins.md`).
 2. Check if this directory has a vault (look for `.obsidian/` folder). If yes, report current vault state.
-3. Check if the MCP server is configured (`claude mcp list`). If not, ask if the user wants to set it up.
+3. Check if the vault is registered with the Obsidian CLI (`obsidian list vaults`). If not, point the user at `skills/wiki/references/cli-setup.md` for the one-time `obsidian register` step.
 4. Ask ONE question: "What is this vault for?"
 
 Then build the entire wiki structure based on the answer. Don't ask more questions. Scaffold it, show what was created, and ask: "Want to adjust anything before we start?"

--- a/skills/braindump/SKILL.md
+++ b/skills/braindump/SKILL.md
@@ -7,12 +7,16 @@ description: >
   CAPTURE pipeline (MATCH/NEW per chunk). Triage later via /note process.
   Triggers on: "/braindump", "brain dump this", "dump the following thoughts",
   "dump these thoughts", "braindump:", "split this into notes".
-allowed-tools: Read Write Edit Glob Grep Bash
+allowed-tools: Bash Read Glob Grep
 ---
 
 # braindump: Long-Form → Atomic Notes
 
 Long-form text that shouldn't interrupt flow — planning sessions, retros, design ramblings. `/braindump` splits the stream into atomic thoughts and files each through the standard CAPTURE pipeline. Chunks land in `notes/` indistinguishable from `/note` captures; triage with `/note process`.
+
+## Vault I/O
+
+This skill writes inbox notes by re-running the per-chunk CAPTURE flow defined in [`_shared/capture-pipeline.md`](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md). All vault writes (note files, `notes/index.md` patches) flow through the `obsidian` CLI per the pipeline contract. `Read` is retained for non-vault input file ingestion (vault-relative or absolute text/markdown paths passed as arguments).
 
 ---
 

--- a/skills/daily-close/SKILL.md
+++ b/skills/daily-close/SKILL.md
@@ -6,12 +6,16 @@ description: >
   date-matched inbox notes, date-matched wiki pages, hot cache, and index.
   Synthesis only — does not triage or clear the inbox.
   Triggers on: "/daily-close", "close today", "wrap up today", "synthesize today".
-allowed-tools: Read Write Edit Glob Bash
+allowed-tools: Bash Read Glob
 ---
 
 # daily-close: End-of-Day Synthesis
 
 Synthesize `<vault_root>/daily/YYYY-MM-DD.md` into a polished prose summary with optional follow-ups. Reads the day's captures, any inbox notes and wiki pages dated to that day, plus `wiki/hot.md` and `wiki/index.md` for cross-reference context. Appends a `## Summary` section (and optional `## Follow-ups`) to the daily file. Re-running replaces the prior summary — idempotent.
+
+## Vault I/O
+
+This skill reads the daily file, dated inbox notes, dated wiki pages, `wiki/hot.md`, and `wiki/index.md`, then writes the synthesized result back to the daily file. All operations go through the `obsidian` CLI: `read` for reads, `properties path=<file>` for date-matched frontmatter scans, and `create overwrite=true` for the atomic synthesis write. See `${CLAUDE_PLUGIN_ROOT}/_shared/cli.md` for verb syntax, multiline `content=` escapes, and the `overwrite` flag semantics.
 
 ---
 
@@ -34,41 +38,40 @@ No vault configured — run /wiki init first.
    - Argument provided → validate it matches `YYYY-MM-DD` format. Abort with `Invalid date: <arg>. Expected YYYY-MM-DD.` if not parseable.
    - Once parsed, check whether the date is in the future. Abort with `Cannot close a future date: <date>.` if future.
 
-3. **Check daily file existence:** If `<vault_root>/daily/YYYY-MM-DD.md` does not exist, abort with `No daily file for YYYY-MM-DD.` (do not auto-create).
+3. **Check daily file existence:** call `obsidian read path=daily/YYYY-MM-DD.md`. Treat exit 1 with `Error: File "..." not found.` as the file-missing branch and abort with `No daily file for YYYY-MM-DD.` (do not auto-create).
 
 4. **Check for empty day:** Scan for content worth synthesizing:
-   - Count bullets under `## Captures` in the daily file.
+   - Count bullets under `## Captures` in the daily file content from step 3.
    - If zero bullets, scan for date-matched activity:
-     - List `<vault_root>/notes/*.md` and read **frontmatter only**. Match `created: YYYY-MM-DD` OR `updated: YYYY-MM-DD` AND `status: pending`.
-     - List `<vault_root>/wiki/**/*.md` and read **frontmatter only**. Match `created: YYYY-MM-DD` OR `updated: YYYY-MM-DD`. Exclude `wiki/hot.md` and `wiki/index.md` (they are always read in full in step 5).
+     - Glob `<vault_root>/notes/*.md` and call `obsidian properties path=notes/<file>` per candidate. Match `created: YYYY-MM-DD` OR `updated: YYYY-MM-DD` AND `status: pending`.
+     - Glob `<vault_root>/wiki/**/*.md` and call `obsidian properties path=wiki/<file>` per candidate. Match `created: YYYY-MM-DD` OR `updated: YYYY-MM-DD`. Exclude `wiki/hot.md` and `wiki/index.md` (they are always read in full in step 5).
    - If both zero bullets AND no matching notes or wiki pages → abort with `Nothing to synthesize for YYYY-MM-DD.` (no LLM call fired).
 
 5. **Gather synthesis input** (frontmatter-first: bodies read only for matched files):
-   - Full daily file (`daily/YYYY-MM-DD.md`, frontmatter + captures).
-   - Each pending note matched in step 4 (frontmatter + body).
-   - Each wiki page matched in step 4 (frontmatter + body).
-   - `wiki/hot.md` in full.
-   - `wiki/index.md` in full.
+   - Full daily file (already read in step 3 — reuse the content).
+   - Each pending note matched in step 4: `obsidian read path=notes/<file>` (frontmatter + body).
+   - Each wiki page matched in step 4: `obsidian read path=wiki/<file>` (frontmatter + body).
+   - `obsidian read path=wiki/hot.md` in full.
+   - `obsidian read path=wiki/index.md` in full.
 
 6. **Call LLM for synthesis** using the prompt template below. If the call fails, abort with `Synthesis failed: <reason>.` and leave the daily file unchanged.
 
-7. **Write synthesized section** to the daily file:
-   - No existing `## Summary` section → append after the last bullet in `## Captures`.
-   - Existing `## Summary` section → remove from the `## Summary` heading through any immediately following `## Follow-ups` section, stopping at the next level-2 heading that is **not** `## Follow-ups`, or at EOF if none exists; then write the new section in its place. Idempotent.
+7. **Construct the updated file content in memory:**
+   - No existing `## Summary` section → append the new section after the last bullet in `## Captures`.
+   - Existing `## Summary` section → remove from the `## Summary` heading through any immediately following `## Follow-ups` section, stopping at the next level-2 heading that is **not** `## Follow-ups`, or at EOF if none exists; insert the new section in its place. Idempotent.
    - Structure: `## Summary` followed by prose, then optional `## Follow-ups` with bulleted items (omit the heading and bullets entirely when no follow-ups).
+   - Bump `updated:` in the frontmatter to today's date (the close-run date, even when closing a past day).
 
-### Atomic write requirement
+8. **Atomic write back via the CLI:**
 
-When updating the daily file, do **not** write directly into the target file in place.
+   ```bash
+   obsidian create \
+     path=daily/YYYY-MM-DD.md \
+     overwrite=true \
+     content="<full updated file content with \n escapes>"
+   ```
 
-Required write strategy:
-1. Read the existing daily file and construct the full replacement content in memory.
-2. Write that full replacement content to a temporary file in the **same directory** as the daily file.
-3. Only after the temporary file has been written successfully, rename/move it over the original daily file in a single replace step.
-4. If any step before the final rename/move fails, abort with the filesystem error and leave the original daily file unchanged.
-5. Best-effort cleanup: remove the temporary file if it still exists after a failed write.
-
-8. **Bump `updated:`** in the daily file's frontmatter to today's date (the close-run date, even when closing a past day).
+   The `overwrite` flag replaces the file in one operation; the wrapper keeps Obsidian's index consistent. If the call returns non-zero, abort with the wrapper's error and leave the daily file unchanged (the upstream CLI either succeeds atomically or reports an error before mutating).
 
 9. **Confirm** with exactly one line:
    ```

--- a/skills/daily/SKILL.md
+++ b/skills/daily/SKILL.md
@@ -5,12 +5,18 @@ description: >
   adds one line to <vault_root>/daily/YYYY-MM-DD.md — no inbox, no triage.
   Triggers on: "/daily", "daily note this", "log to today", "log this",
   "add to today's log", "daily log:".
-allowed-tools: Read Write Edit Glob Bash
+allowed-tools: Bash Read Glob
 ---
 
 # daily: Chronological Daily Log
 
 Append a timestamped bullet to `<vault_root>/daily/YYYY-MM-DD.md`. No MATCH/NEW decision, no inbox, no triage. Every invocation adds one bullet. Use `/note` for knowledge fragments worth triaging later; use `/daily` for time-anchored observations, progress notes, and anything that belongs to the day.
+
+## Vault I/O
+
+This skill creates and updates `<vault_root>/daily/YYYY-MM-DD.md`. All vault writes go through the `obsidian` CLI (`create`, `read`, `append`, `create overwrite=true` for atomic frontmatter rewrites). See `${CLAUDE_PLUGIN_ROOT}/_shared/cli.md` for verb syntax, multiline `content=` escapes, and the `overwrite` flag.
+
+The local `daily/` directory is filesystem state, not a vault page; create it via `mkdir -p` if missing (the CLI does not create parent directories).
 
 ---
 
@@ -40,27 +46,36 @@ Steps:
 
 1. **Extract arguments** from the user's message. Everything after the trigger phrase. Scan for image-path tokens (any token that resolves to a path or carries a supported image extension); keep them separate. Join the remaining non-path tokens as the verbatim text segment in original order with single spaces. Do not include image-path tokens in the verbatim text.
 
-2. **Image routing.** If any image paths are present → read `${CLAUDE_PLUGIN_ROOT}/_shared/image-capture.md` then `${CLAUDE_PLUGIN_ROOT}/skills/daily/references/image-capture.md`. Use those files to determine the image-specific bullet text and attachment handling only. Then continue with steps 3–10 below for the normal daily append flow — resolve `<vault_root>`, compute date/time, ensure daily file, ensure `## Captures`, append the generated content, bump `updated:`, and confirm.
+2. **Image routing.** If any image paths are present → read `${CLAUDE_PLUGIN_ROOT}/_shared/image-capture.md` then `${CLAUDE_PLUGIN_ROOT}/skills/daily/references/image-capture.md`. Use those files to determine the image-specific bullet text and attachment handling only. Then continue with steps 3–9 below for the normal daily append flow — resolve `<vault_root>`, compute date/time, ensure daily directory, probe and write the daily file via the CLI, and confirm.
 
 3. **Resolve** `<vault_root>` per [§1](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). Abort with `No vault configured — run /wiki init first.` if unresolved.
 
 4. **Compute** today as `YYYY-MM-DD` and current local time as `HH:MM` (24-hour, zero-padded).
 
-5. **Ensure directory:** if `<vault_root>/daily/` does not exist, create it silently.
+5. **Ensure directory:** if `<vault_root>/daily/` does not exist, create it silently with `mkdir -p`. (Local directory creation, not a vault page op.)
 
-6. **Ensure file:** if `<vault_root>/daily/YYYY-MM-DD.md` does not exist, create it per [§7](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#7-daily-page-append-shape) — frontmatter from [§2](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#2-frontmatter-schema-note--daily) plus an empty `## Captures` section.
+6. **Probe the file:** call `obsidian read path=daily/YYYY-MM-DD.md`. Treat exit 1 with `Error: File "..." not found.` as the file-missing branch.
 
-7. **Ensure heading:** if `## Captures` is missing, append it at EOF before the bullet (idempotent — never duplicate).
+7. **File-missing branch:** create the file with frontmatter from [§2](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#2-frontmatter-schema-note--daily) plus an empty `## Captures` section, plus the new bullet, in one atomic write:
 
-8. **Append** one bullet under `## Captures`:
-
+   ```bash
+   obsidian create \
+     path=daily/YYYY-MM-DD.md \
+     content="---\ntype: daily\ndate: YYYY-MM-DD\ncreated: YYYY-MM-DD\nupdated: YYYY-MM-DD\n---\n\n## Captures\n- HH:MM <verbatim text>\n"
    ```
-   - HH:MM <verbatim text>
+
+8. **File-exists branch:** parse the file content from step 6. If the `## Captures` heading is present, append one bullet under it; if it is missing, append the heading and the bullet at EOF. Bump `updated:` in the frontmatter to today. Then write the full updated content back atomically:
+
+   ```bash
+   obsidian create \
+     path=daily/YYYY-MM-DD.md \
+     overwrite=true \
+     content="<full updated file content with \n escapes>"
    ```
 
-9. **Bump** `updated:` in frontmatter to today.
+   The `overwrite` flag replaces the file in one operation; no temp-file dance is required at the skill layer (Obsidian's index stays consistent through the wrapper).
 
-10. **Confirm** with exactly one line:
+9. **Confirm** with exactly one line:
     ```
     Logged to daily/YYYY-MM-DD.md
     ```

--- a/skills/notes/SKILL.md
+++ b/skills/notes/SKILL.md
@@ -78,7 +78,7 @@ Goal: show pending and deferred notes for triage.
 
 Steps:
 
-1. Read `<vault_root>/notes/*.md` frontmatter (title, source_project, status, updated). Skip `notes/index.md`. For each note file, call `obsidian properties format=json path=notes/<filename>` to extract frontmatter as JSON. Inbox is bounded by user discipline; serial reads are acceptable.
+1. Read `<vault_root>/notes/*.md` frontmatter (title, source_project, status, updated). Skip `notes/index.md`. For each note file, call `obsidian properties path=notes/<filename>` to extract the YAML frontmatter block (plain-text output; no `format=json` support — see `${CLAUDE_PLUGIN_ROOT}/_shared/cli.md` §3). Inbox is bounded by user discipline; serial reads are acceptable.
 2. Sort by `updated` descending.
 3. Render flat reverse-chronological bullets:
 

--- a/skills/obsidian-bases/SKILL.md
+++ b/skills/obsidian-bases/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: obsidian-bases
 description: "Create and edit Obsidian Bases (.base files): Obsidian's native database layer for dynamic tables, card views, list views, filters, formulas, and summaries over vault notes. Triggers on: create a base, add a base file, obsidian bases, base view, filter notes, formula, database view, dynamic table, task tracker base, reading list base."
-allowed-tools: Read Write
+allowed-tools: Bash Read Glob
 ---
 
 # obsidian-bases: Obsidian's Database Layer
@@ -9,6 +9,17 @@ allowed-tools: Read Write
 Obsidian Bases (launched 2025) turns vault notes into queryable, dynamic views. Tables, cards, lists, maps. Defined in `.base` files. No plugin required; it is a core Obsidian feature.
 
 **Authoritative reference**: If the kepano/obsidian-skills plugin is installed, prefer its canonical obsidian-bases skill. Otherwise, use the reference below. Official docs: https://help.obsidian.md/bases/syntax
+
+## Vault I/O
+
+This skill creates and edits `.base` files inside the vault. All reads and writes go through the `obsidian` CLI:
+
+- Read an existing base: `obsidian read path=wiki/meta/<name>.base`
+- List existing bases: `obsidian bases`
+- Create a new base: `obsidian create path=wiki/meta/<name>.base content="<yaml with \n escapes>"`
+- Replace an existing base: `obsidian create path=... overwrite=true content=...` (read first, modify in memory, write atomically)
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/cli.md` for verb syntax, multiline `content=` escapes, and the `overwrite` flag.
 
 ---
 

--- a/skills/obsidian-markdown/SKILL.md
+++ b/skills/obsidian-markdown/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: obsidian-markdown
 description: "Write correct Obsidian Flavored Markdown: wikilinks, embeds, callouts, properties, tags, highlights, math, and canvas syntax. Reference this when creating or editing any wiki page. Triggers on: write obsidian note, obsidian syntax, wikilink, callout, embed, obsidian markdown, wikilink format, callout syntax, embed syntax, obsidian formatting, how to write obsidian markdown."
-allowed-tools: Read
+allowed-tools: Read Write Edit
 ---
 
 # obsidian-markdown: Obsidian Flavored Markdown

--- a/skills/obsidian-markdown/SKILL.md
+++ b/skills/obsidian-markdown/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: obsidian-markdown
 description: "Write correct Obsidian Flavored Markdown: wikilinks, embeds, callouts, properties, tags, highlights, math, and canvas syntax. Reference this when creating or editing any wiki page. Triggers on: write obsidian note, obsidian syntax, wikilink, callout, embed, obsidian markdown, wikilink format, callout syntax, embed syntax, obsidian formatting, how to write obsidian markdown."
-allowed-tools: Read Write Edit
+allowed-tools: Read
 ---
 
 # obsidian-markdown: Obsidian Flavored Markdown

--- a/skills/wiki/references/cli-setup.md
+++ b/skills/wiki/references/cli-setup.md
@@ -122,7 +122,75 @@ If Obsidian is closed or the CLI is not installed:
 
 ## Examples
 
-TBD — follow-up PR #52 will add practical examples (ingest a source, query the wiki, etc.).
+End-to-end snippets pulled from the converted skills. All vault I/O routes through the wrapper; the `obsidian` invocations below are transparently rewritten to `scripts/obsidian-cli.sh` by the PreToolUse hook.
+
+### Ingest a source
+
+```bash
+# 1. Pull the raw source into .raw/ (direct file op — non-vault path)
+curl -sL "$URL" > .raw/article-2026-04-29.md
+
+# 2. Read existing index for cross-reference candidates
+obsidian read path=wiki/index.md
+
+# 3. Create the new wiki page
+obsidian create path=wiki/concepts/distributed-tracing.md content="---
+title: Distributed Tracing
+type: concept
+tags: [observability]
+---
+
+# Distributed Tracing
+
+See [[opentelemetry]] for the data model.
+"
+
+# 4. Append a one-line entry to the index and the operations log
+obsidian append path=wiki/index.md content="- [[distributed-tracing]] — span-level request correlation"
+obsidian append path=wiki/log.md content="- 2026-04-29 ingested distributed-tracing from .raw/article-2026-04-29.md"
+```
+
+### Query the wiki
+
+```bash
+# Hot cache first (cheap)
+obsidian read path=wiki/hot.md
+
+# Full-text search across the vault, JSON for parsing
+obsidian search query="rate limiting" format=json
+
+# Pull backlinks for a known page to walk the graph
+obsidian backlinks path=wiki/concepts/distributed-tracing.md format=json
+
+# Read the candidate page
+obsidian read path=wiki/concepts/distributed-tracing.md
+```
+
+### Save a conversation insight
+
+```bash
+# Overwrite-safe create for a new note
+obsidian create path=wiki/concepts/cache-stampede.md overwrite=true content="---
+title: Cache Stampede
+type: concept
+---
+
+# Cache Stampede
+
+Triggered when many clients miss the cache simultaneously..."
+
+# Prepend a TL;DR to an existing page
+obsidian prepend path=wiki/concepts/caching.md content="> See also: [[cache-stampede]]"
+```
+
+### Lint primitives (issue #45 data layer)
+
+```bash
+obsidian orphans
+obsidian deadends
+obsidian unresolved format=json
+obsidian backlinks path=wiki/index.md format=json
+```
 
 ---
 


### PR DESCRIPTION
Closes #53. Final sub-issue of the CLI migration epic #48 — also closes the epic.

## Summary

- Drop the last residual Local REST API / MCP references from `_seed/FIRST_RUN.md` (install steps) and `_shared/capture-pipeline.md` (bulk-frontmatter step).
- Fill the TBD Examples block in `skills/wiki/references/cli-setup.md` with end-to-end snippets for ingest, query, save, and the lint primitives that unblock #45.
- Bump plugin manifest to **1.0.0** and add a `[1.0.0] — 2026-04-29` CHANGELOG entry covering the breaking change (Obsidian 1.12.7+ required), the MCP path removal, migration steps, the optional `pkill -f mcp-obsidian` cleanup, and the rollback recipes (`v0.5.1` for mixed-mode, `v0.4.0` for full MCP).
- External plugin authors: `mcp__obsidian-vault__*` is gone in 1.0.0 — migrate to the `obsidian` CLI per `_shared/cli.md`.

## Acceptance criteria

- [x] **#1** `grep -rn "mcp__obsidian" skills/ _shared/ hooks/ commands/ scripts/ bin/` → 0 matches.
- [x] **#2** `grep -rn "Local REST\|REST API\|localhost:2712[34]\|NODE_TLS_REJECT_UNAUTHORIZED" .` → matches only in `CHANGELOG.md` (exempt) and `.claude/settings.local.json` (gitignored, local user state).
- [x] **#3** No default MCP server entry in any plugin-shipped settings — confirmed; repo ships none.
- [x] **#4** `mcp__obsidian-vault__*` removed from all skill `allowed-tools` frontmatter — already cleared in #51, re-verified.
- [x] **#5** `CHANGELOG.md` documents the breaking change, MCP removal, rollback, optional `pkill` cleanup, and the external-author migration note.
- [x] **#6** TBD example sections in `cli-setup.md` are filled with practical snippets pulled from the converted skills.

## Test plan

- [ ] Re-run the AC #1 and AC #2 grep targets locally; confirm zero in-repo matches outside the documented exemptions.
- [ ] Smoke test on a vault running Obsidian 1.12.7+: `obsidian register` → `obsidian read path=wiki/hot.md` → `/wiki query` round-trip.
- [ ] Sanity-check the new `cli-setup.md` snippets against `tests/cli-smoke.sh` (the format defaults match the spike-pinned table).
- [ ] Verify the SessionStart fail-soft warning still fires when Obsidian is closed (no regression from 0.5.x).