### PR TITLE
feat(query,lint): backlink-aware traversal and density check

### DIFF
--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -20,6 +20,7 @@ Use the native `obsidian` CLI verbs for efficient data gathering:
 - Orphan pages: `obsidian orphans` (returns one path per line)
 - Dead links: `obsidian deadends` (returns one path per line)
 - Unresolved links: `obsidian unresolved format=json` (returns `[{"link": "..."}]`)
+- Inbound links per page: `obsidian backlinks path=<page> format=json` (returns `[{"file": "<path>"}]`; count entries for the inbound-link count)
 
 Work through these in order:
 
@@ -35,7 +36,8 @@ Work through these in order:
    - **WARN** if word count > 500 (spec limit per `_shared/hot-cache-protocol.md`).
    - **FAIL** if word count > 750 (50 % buffer exceeded).
    - Remediation: move entries older than 2 weeks to `wiki/log.md`; trim `## Last Updated` to the 3–5 most recent items.
-10. **Notes inbox**. Scoped to `<vault_root>/notes/` only. Two checks:
+10. **Backlink density**. For every page under `wiki/` (skip `wiki/meta/` and `notes/`), compute the inbound count via `obsidian backlinks path=<page>` and the outbound count from the page's frontmatter `related:` length plus inline wikilinks. Flag pages where `inbound ≥ 3` **and** `outbound ≤ 1` — heavily cited but weakly linking. These pages are retrieval-late under the forward-only `related:` model, so surfacing them prompts targeted cross-linking. Compute on demand; no backlink index is persisted.
+11. **Notes inbox**. Scoped to `<vault_root>/notes/` only. Two checks:
     - **Frontmatter gaps** — flag any `notes/*.md` (excluding `notes/index.md`) missing one of: `type`, `title`, `created`, `updated`, `source_project`, `status`. The `topic` and `tags` fields are optional and never flagged.
     - **Index drift** — flag any file in `notes/` that is missing from `notes/index.md`, and any row in `notes/index.md` whose title text doesn't match any existing note's frontmatter `title:` field. Match against frontmatter `title:`, not filenames — filenames are slugs that may diverge from display titles after CAPTURE rewrites (AC4).
     - **Explicitly skip** orphan checks, dead-link checks, stale-claim checks, and contradictions for `notes/`. These are wiki-canonical concerns and inappropriate for a transient inbox.
@@ -81,6 +83,9 @@ status: developing
 
 ## Cross-Reference Gaps
 - [[Entity Name]] mentioned in [[Page A]] without a wikilink.
+
+## Backlink Density
+- [[Page Name]]: N inbound, M outbound. Heavily cited, weakly linking. Suggest: add `related:` entries on this page to its top citers, or thread it into a domain hub.
 
 ## Hot Cache Size
 - hot.md: N words (spec: 500, delta: +N). Status: OK | WARN | FAIL

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -37,7 +37,7 @@ Use when the answer is likely in the hot cache or index summary.
 3. If found in index summary, respond and do not open any pages.
 4. If not found, say "Not in quick cache. Run as standard query?"
 
-Do not open individual wiki pages in quick mode.
+Do not open individual wiki pages in quick mode. Do not call `obsidian backlinks` in quick mode — backlink-aware ranking belongs to standard and deep modes; quick mode preserves a ~1.5K token budget.
 
 ---
 
@@ -45,10 +45,12 @@ Do not open individual wiki pages in quick mode.
 
 1. **Read** `wiki/hot.md` first. It may already have the answer or directly relevant context.
 2. **Read** `wiki/index.md` to find the most relevant pages (scan for titles and descriptions).
-3. **Read** those pages. Follow wikilinks to depth-2 for key entities. No deeper.
-4. **Synthesize** the answer in chat. Cite sources with wikilinks: `(Source: [[Page Name]])`.
-5. **Offer to file** the answer: "This analysis seems worth keeping. Should I save it as `wiki/questions/answer-name.md`?"
-6. If the question reveals a **gap**: say "I don't have enough on X. Want to find a source?"
+3. **Rank candidates by inbound citations.** For the shortlist of candidate pages from step 2 (and any pages reached via depth-1 links), run `obsidian backlinks path=<page> format=json` and use the inbound count as a relevance signal alongside title and `related:` matches. A heavily cited atomic note must surface in the top-N even if its outbound `related:` is sparse — backlinks are the only retrieval signal for canonical pages under the forward-only hub model.
+4. **Read** those pages. Follow wikilinks to depth-2 for key entities. No deeper.
+5. **Step from leaf to hub when needed.** If a candidate page is a leaf and you need its broader topic context, run `obsidian backlinks path=<leaf> format=json` and read the entries whose frontmatter `type: domain` — that file is the leaf's containing hub. Hub membership is forward-only (hubs link to leaves; leaves never declare membership), so backlinks of `type: domain` are the canonical leaf→hub traversal.
+6. **Synthesize** the answer in chat. Cite sources with wikilinks: `(Source: [[Page Name]])`.
+7. **Offer to file** the answer: "This analysis seems worth keeping. Should I save it as `wiki/questions/answer-name.md`?"
+8. If the question reveals a **gap**: say "I don't have enough on X. Want to find a source?"
 
 ---
 
@@ -58,10 +60,11 @@ Use for synthesis questions, comparisons, or "tell me everything about X."
 
 1. Read `wiki/hot.md` and `wiki/index.md`.
 2. Identify all relevant sections (concepts, entities, sources, comparisons).
-3. Read every relevant page. No skipping.
-4. If wiki coverage is thin, offer to supplement with web search.
-5. Synthesize a comprehensive answer with full citations.
-6. Always file the result back as a wiki page. Deep answers are too valuable to lose.
+3. **Pull backlinks for every candidate.** Run `obsidian backlinks path=<page> format=json` on each candidate to surface canonical pages with high inbound but sparse outbound `related:`, and to find the `type: domain` hubs that contain each leaf. Read the hubs to recover topic-level structure the leaves themselves don't declare.
+4. Read every relevant page. No skipping.
+5. If wiki coverage is thin, offer to supplement with web search.
+6. Synthesize a comprehensive answer with full citations.
+7. Always file the result back as a wiki page. Deep answers are too valuable to lose.
 
 ---
 


### PR DESCRIPTION
Closes #45.

## Summary

- **lint** (`skills/lint/SKILL.md`): new check #10 *Backlink density* — for every `wiki/` page (excluding `wiki/meta/` and `notes/`), compute inbound count via `obsidian backlinks path=<page>` and flag pages with `inbound ≥ 3 && outbound ≤ 1`. Surfaced in a new *Backlink Density* report section. Computation is on-demand; no backlink index is persisted (per the issue's out-of-scope note).
- **query** (`skills/query/SKILL.md`):
  - **Standard** — added an inbound-citation ranking step and an explicit leaf→hub step that reads `obsidian backlinks` entries with frontmatter `type: domain`.
  - **Deep** — pulls backlinks for every candidate to recover topic structure from the forward-only hub model.
  - **Quick** — explicitly forbids `obsidian backlinks` calls to preserve the ~1.5K token budget (AC4).

## Acceptance criteria

- [x] AC1 — `/lint` surfaces pages with ≥3 inbound and few outbound under *Backlink Density*.
- [x] AC2 — `/query` ranks heavily-cited atomic notes into top-N via inbound count even when outbound `related:` is sparse.
- [x] AC3 — From a leaf, `/query` reads `obsidian backlinks` and follows entries with `type: domain` to find the containing hub.
- [x] AC4 — Quick mode unchanged: still reads `hot.md` + `index.md`, no backlink calls. Token budget preserved.

## Manual testing

In a vault with at least one heavily-cited atomic note:

1. Pick (or create) a `wiki/concepts/<X>.md` page that is referenced from ≥3 other pages but has 0–1 outbound `related:`/wikilinks.
2. Run `/lint` on the vault. Verify the *Backlink Density* section lists the page with `inbound ≥ 3, outbound ≤ 1`.
3. Run `/query` (standard mode) on a topic where that page is canonical. Verify the page surfaces in the top-N answer set even though its `related:` is sparse.
4. From a leaf page that lives under a `wiki/domains/<hub>.md` (where the hub has `type: domain` and links to the leaf), ask the agent to identify the leaf's containing hub. Verify it runs `obsidian backlinks path=<leaf>` and reads the `type: domain` result.
5. Run `/query quick: <factual question>` and verify the agent reads only `hot.md` + `index.md` — no `obsidian backlinks` invocation, total tokens around the 1.5K budget.

## Out of scope (per issue)

- Persisting a backlink index file (computed on demand).
- Adding a reverse-link frontmatter field (rejected; backlinks remain computed).