### PR TITLE
fix(save): section-aware index insert replaces whole-file prepend

### DIFF
--- a/scripts/index-section-insert.sh
+++ b/scripts/index-section-insert.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# index-section-insert.sh — insert an entry under a heading in a vault index file.
+#
+# Reads the target file via `obsidian read`, splices the entry on the line
+# immediately after the matching heading (newest-at-top within the section),
+# and writes back via `obsidian create overwrite=true`. If the heading is
+# absent, appends `<heading>\n<entry>` at the end of the file.
+#
+# Used by /save (skills/save/SKILL.md step 7) and /wiki promote
+# (skills/wiki/references/operation-promote.md step 7) to maintain
+# wiki/index.md without misplacing entries — `obsidian prepend` is
+# whole-file, not section-aware.
+#
+# Usage:
+#   index-section-insert.sh <vault-relative-path> <section-heading> <entry>
+#
+# Example:
+#   index-section-insert.sh wiki/index.md "## Concepts" "- [[foo|Foo]] — bar"
+#
+# Exit codes:
+#   0 — success
+#   1 — argument error
+#   * — propagated from obsidian-cli.sh (read/create failure)
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: index-section-insert.sh <path> <section> <entry>" >&2
+  exit 1
+fi
+
+path="$1"
+section="$2"
+entry="$3"
+
+cli="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT must be set}/scripts/obsidian-cli.sh"
+
+current=$("$cli" read "file=$path")
+
+if printf '%s\n' "$current" | grep -qxF "$section"; then
+  updated=$(printf '%s\n' "$current" | awk -v h="$section" -v e="$entry" \
+    '$0 == h { print; print e; next } 1')
+else
+  updated=$(printf '%s\n\n%s\n%s' "$current" "$section" "$entry")
+fi
+
+"$cli" create "path=$path" "overwrite=true" "content=$updated"

--- a/skills/save/SKILL.md
+++ b/skills/save/SKILL.md
@@ -54,11 +54,27 @@ If the user specifies a type, use that. If not, pick the best fit based on the c
      content="<frontmatter + body, with \n for newlines>"
    ```
 6. **Collect links**: identify any wiki pages mentioned in the conversation. Include them in `related` in the frontmatter you pass via `content=`.
-7. **Update** `wiki/index.md`. Prepend the new entry under the relevant section:
+7. **Update** `wiki/index.md`. Use a read-splice-overwrite pattern to insert the entry under the correct section heading.
+
+   **Type → section** (deterministic; do not choose freehand):
+
+   | Note type | Target section |
+   |-----------|----------------|
+   | `concept` | `## Concepts` |
+   | `source` | `## Sources` |
+   | `decision` | `## Plans & Decisions` |
+   | `synthesis` | `## Questions` |
+   | `session` | *(skip — not indexed; chronology lives in `wiki/log.md` and `daily/`)* |
+
+   **Entry format:** `- [[<slug>|<Display Name>]] — <one-line description>`
+   Omit `|<Display Name>` when the display name matches the slug exactly (after converting hyphens/underscores to spaces and title-casing).
+
+   **Pattern:** delegate the read-splice-overwrite to `scripts/index-section-insert.sh`. It reads via `obsidian read`, splices the entry on the line immediately after the matching heading, and writes back via `obsidian create overwrite=true`. If the heading is absent, the script appends `<heading>\n<entry>` at the end of the file.
    ```bash
-   obsidian prepend \
-     file=wiki/index.md \
-     content="- [[<slug>]]: <one-line description>\n"
+   # section is determined from the type table above
+   new_entry="- [[$slug|$display_name]] — $description"
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/index-section-insert.sh" \
+     wiki/index.md "$section" "$new_entry"
    ```
 8. **Prepend** the latest entry to `wiki/log.md` (new entry goes at the TOP):
    ```bash

--- a/skills/wiki/references/operation-promote.md
+++ b/skills/wiki/references/operation-promote.md
@@ -55,7 +55,15 @@ Use this when `/lint` reports a **promotion candidate** (a tag-cluster of ≥10 
    - ...
    ```
    Empty sections (no leaves of that type) can be omitted. The one-line description should be the leaf's own description if its frontmatter has one, otherwise leave it as `<TODO: describe>` for the human curator.
-7. **Update `wiki/index.md`.** Prepend an entry under the `## Domains` section.
+7. **Update `wiki/index.md`.** Splice an entry under the `## Domains` section via `scripts/index-section-insert.sh` (same helper as `/save` step 7).
+
+   **Entry format:** `- [[domains/<tag>/_index|<Title Case>]] — <one-line description>`
+
+   ```bash
+   new_entry="- [[domains/$tag/_index|$title]] — $stub_one_line"
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/index-section-insert.sh" \
+     wiki/index.md "## Domains" "$new_entry"
+   ```
 8. **Update `wiki/hot.md`.** Add the new hub to the `## Recent Changes` list per the hot-cache protocol.
 9. **Update `wiki/log.md`.** Prepend a `## [YYYY-MM-DD] promote | <tag>` entry noting the new hub and the cluster size.
 10. **Confirm.** "Scaffolded [[domains/<tag>/_index]] with N pre-populated leaves. Open it in Obsidian to curate descriptions and section ordering."


### PR DESCRIPTION
## Summary

- Replaces `obsidian prepend` in `/save` step 7 with a read-splice-overwrite pattern (`obsidian read` + `awk` splice + `obsidian create overwrite=true`). The old prepend was whole-file, landing entries above the `# Wiki Index` H1 with no section context.
- Extracts the splice mechanism into a shared helper at `scripts/index-section-insert.sh` so `/save` and `/wiki promote` share one source of truth (per CLAUDE.md "extract over repeat").
- Adds a deterministic **type → section** mapping in `/save` (`concept` → `## Concepts`, `source` → `## Sources`, `decision` → `## Plans & Decisions`, `synthesis` → `## Questions`, `session` skip). The agent no longer chooses freehand.
- Aligns the example entry format to `- [[<slug>|<Display Name>]] — <description>` (no colon, no status suffix — leaf frontmatter is the source of truth for status).
- Applies the same fix to `skills/wiki/references/operation-promote.md` step 7 (`## Domains` section), since it carried the identical bug.
- Missing-heading behavior: the helper appends `<heading>\n<entry>` at end of file rather than aborting (keeps `/save` non-blocking).

## Manual testing

The helper was verified end-to-end against a live vault during this session:

1. Open Obsidian with a vault registered with the CLI; ensure `${CLAUDE_PLUGIN_ROOT}` resolves.
2. Section-exists branch:
   ```bash
   bash "${CLAUDE_PLUGIN_ROOT}/scripts/index-section-insert.sh" \
     wiki/index.md "## Concepts" "- [[test-entry|Test]] — verifying the splice"
   ```
   Confirm the bullet lands on the line immediately after `## Concepts` (newest-at-top), **not** above `# Wiki Index`.
3. Missing-heading branch:
   ```bash
   bash "${CLAUDE_PLUGIN_ROOT}/scripts/index-section-insert.sh" \
     wiki/index.md "## Made Up" "- [[test-entry|Test]] — heading does not exist"
   ```
   Confirm the heading + entry are appended at the end of the file.
4. Argument-error branch: `bash …/index-section-insert.sh` with the wrong arg count → exits 1 with usage line.
5. Revert the test edit in the vault.

## Acceptance

- [x] AC1: `/save` step 7 example uses a concrete read-splice-overwrite snippet (delegated to the helper).
- [x] AC2: Example content matches `- [[slug|Display Name]] — description`.
- [x] AC3: Type → section is a deterministic table (no agent choice).
- [x] AC4: `skills/wiki/references/operation-promote.md:58` carries the same fix.

Closes #84