### PR TITLE
Drop Wiki Map.canvas seed reference (closes #80)

### DIFF
--- a/_seed/FIRST_RUN.md
+++ b/_seed/FIRST_RUN.md
@@ -108,7 +108,6 @@ Keep the structural pages (`hot.md`, `index.md`, `log.md`, `overview.md`).
 
 ### Views
 
-- `wiki/Wiki Map.canvas` — knowledge graph canvas (created once you add content)
 - Graph view — filtered to `wiki/` only, color-coded by page type
 
 ### Visual layout (optional)


### PR DESCRIPTION
## Summary

- Removes the single `_seed/FIRST_RUN.md` reference to `wiki/Wiki Map.canvas`.
- Closes #80 in lieu of building documentation, lint coverage, and a refresh operation around the canvas.

## Why

#80 proposed three deliverables (docs, lint drift check, hub-column refresh op) to keep `wiki/Wiki Map.canvas` trustworthy. Re-evaluating against the plugin's `agent-only, single-user, single-machine` framing in `CLAUDE.md`:

- The agent already has `wiki/hot.md` (entry point), `wiki/index.md` (flat registry), `wiki/domains/*/_index.md` (12 hubs), `related:` frontmatter (typed cross-links), `tags:` + folder partition, and backlink-aware traversal (#45). The canvas duplicates the domain-hub list `index.md` already maintains.
- The canvas's only unique semantic content is labeled edges (e.g. `llm-wiki --originated by--> karpathy`). That belongs in frontmatter where it's greppable from either endpoint, not in a `.canvas` JSON node label that no skill reads.
- Spatial positions and colors carry zero signal for an agent.
- Net effect: a `.canvas` file is *denser per byte* than equivalent markdown for the same retrieval surface, and it generates recurring `[[Wiki Map]]` dangling-link noise in lint reports (per #80's own evidence).

For a human Obsidian user, the canvas has real value (visual recall, shareable artifact). For the agent — the actual consumer this plugin targets — it is dead weight. Hence dropping the seeded reference rather than investing in maintenance tooling.

## Scope

- **In scope:** the one `_seed/FIRST_RUN.md` line.
- **Not touched:** the `Canvas Map` section in `skills/lint/SKILL.md` (prescribes a different canvas, `wiki/meta/overview.canvas`) — same agent-value question applies and would warrant a separate issue.
- **User vault:** deleting the actual `wiki/Wiki Map.canvas` and cleaning up `[[Wiki Map]]` wikilinks lives in the user's personal vault, not in this plugin repo.

## Test plan

- [x] `grep -rn "Wiki[ -]Map" .` returns no hits in plugin source after the change.
- [ ] Fresh `/wiki init` no longer mentions a `Wiki Map.canvas` in onboarding output.

Closes #80.