### PR TITLE
fix(plugin): register commands directory in manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -25,6 +25,7 @@
     "canvas",
     "visual"
   ],
+  "commands": "./commands/",
   "userConfig": {
     "vault_path": {
       "title": "Vault path",


### PR DESCRIPTION
## Summary

- One-line fix in `.claude-plugin/plugin.json`: add `\"commands\": \"./commands/\"` so Claude Code registers every command file with its bare alias.
- Without this field, bare slash commands (`/wiki`, `/daily`, `/save`, ...) silently fall through to "Unknown command"; only the namespaced forms (`/claude-obsidian:wiki`, etc.) work.

Closes #97.

## Test plan

- [x] `/wiki init` works in interactive Claude Code v2.1.126
- [x] `/daily test` works
- [x] `/save` works
- [x] Namespaced forms (`/claude-obsidian:wiki`) continue to work
- [x] `claude -p "/wiki init"` from a non-interactive shell

## Discovery context

Surfaced while bringing up the local E2E full tier (PR #94 / issue #91). The harness pivoted to namespaced forms to unblock itself; once this lands, callers can use either form.