### PR TITLE
fix(lint): make dead-link check deterministic via lint-scan.sh

### DIFF
--- a/_shared/cli.md
+++ b/_shared/cli.md
@@ -119,7 +119,27 @@ The following paths bypass the CLI intentionally. Each bypass is load-bearing; d
 
 ---
 
-## 7. Re-spiking after a CLI version bump
+## 7. Canvas file handling
+
+Canvas files (`.canvas`) are first-class vault documents, but the Obsidian CLI has no canvas-specific verbs. Skills that need to work with canvases use a combination of standard verbs and direct filesystem reads.
+
+| Operation | Approach |
+|-----------|----------|
+| List canvas files | `obsidian files dir=wiki/canvases format=json` — returns `[{"path": "wiki/canvases/foo.canvas", ...}]` |
+| Read canvas content | Direct filesystem read (documented bypass — canvas JSON is not Markdown; `obsidian read` returns raw JSON but the `content=` escape asymmetry in §3 does not affect reads) |
+| Extract wikilinks | Parse `.nodes[]?.text` JSON fields for `[[...]]` patterns. `obsidian unresolved` does **not** cover canvas wikilinks — a separate pass using the filesystem resolver pool is required. |
+| Verify canvas dead links | Build a resolver pool from `find $VAULT -name "*.md" -o -name "*.canvas" ...` and test each extracted link against it. Reference implementation: `scripts/lint-scan.sh`. |
+| Write canvas files | Direct filesystem write (documented bypass — canvas JSON `text` fields contain literal `\n` sequences that `content=` would corrupt per §3 escape asymmetry) |
+| Backlinks to a canvas | `obsidian backlinks path=wiki/canvases/foo.canvas format=json` — works identically to `.md` files |
+
+**`obsidian files` verb** (not in the §3 table; no locked output format):
+- `obsidian files dir=<vault-relative-dir> format=json` → `[{"path": "<vault-relative-path>", ...}]`
+- Works for any directory: `wiki/canvases/`, `wiki/meta/`, `notes/`, etc.
+- Extension filtering is not supported by the verb — filter client-side with `jq select(.path | endswith(".canvas"))`
+
+---
+
+## 8. Re-spiking after a CLI version bump
 
 After any Obsidian minor-version upgrade, re-run `scripts/cli-spike.sh` and diff `tests/spike-results/` against the committed baseline. Update this file if:
 

--- a/agents/lint.md
+++ b/agents/lint.md
@@ -22,42 +22,51 @@ You will be given:
 - The vault path
 - The scope (full wiki, or a specific folder)
 
-## Your Process
+## Step 1 — Run the deterministic scan
 
-1. Read `wiki/index.md` to get the full list of pages.
-2. For each wiki page, check:
-   - Frontmatter has required fields (type, status, created, updated, tags)
-   - All wikilinks in the page resolve to real files
-   - All headings have content underneath them
-   - Page is linked from at least one other page (no orphans)
-3. Scan for concepts and entities mentioned in multiple pages but lacking their own page.
-4. Scan for unlinked mentions (entity names appearing without `[[` brackets).
-5. Check `wiki/index.md` for stale entries pointing to renamed/deleted files.
-6. Identify pages with status `seed` that have not been updated in over 30 days.
+Before doing any enumeration yourself, invoke the scan script to produce a canonical JSON snapshot:
+
+```bash
+CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}" \
+  bash "${CLAUDE_PLUGIN_ROOT}/scripts/lint-scan.sh"
+```
+
+Read the resulting `wiki/meta/lint-data-YYYY-MM-DD.json` (today's date). This file is the authoritative source for:
+
+- **`dead_links`** — `[{source_page, link_text}]` broken wikilinks across `.md` and `.canvas` sources
+- **`orphans`** — pages with no inbound wikilinks (trails and notes already excluded)
+- **`unresolved_targets`** — `[{link}]` all unresolved link texts (for reference)
+- **`backlinks`** — `{page_path: count}` inbound link count per in-scope page
+- **`anti_patterns`** — URL-as-wikilink occurrences (reported separately, not counted as dead links)
+- **`scope`** — the exact folders and extensions that were scanned
+
+Do **not** run `obsidian deadends`, `obsidian orphans`, or per-page `obsidian backlinks` loops yourself — the JSON already contains those results, sorted and deterministic.
+
+## Step 2 — Agent-driven checks
+
+After reading the JSON, perform the checks that require reading page content or exercising judgment. Work through the checks defined in `skills/lint/SKILL.md` in order, using the JSON where it provides data and reading individual pages only for checks that require full content:
+
+- **Check #1 (orphans):** use `orphans` from JSON.
+- **Check #2 (dead links):** use `dead_links` from JSON. Canvas dead links are already merged in.
+- **Check #3 (stale claims):** requires reading pages — do this yourself.
+- **Check #4 (missing pages):** requires reading pages — do this yourself.
+- **Check #5 (missing cross-references):** requires reading pages — do this yourself.
+- **Check #6 (frontmatter gaps):** read each in-scope page; use `scope.scanned_dirs` from JSON for the exact directory list.
+- **Check #7 (empty sections):** requires reading pages.
+- **Check #8 (stale index entries):** use `obsidian read path=wiki/index.md` then validate each link.
+- **Check #9 (hot.md size budget):** `obsidian read path=wiki/hot.md` then count words.
+- **Check #10 (backlink density):** use `backlinks` from JSON. No additional CLI calls needed.
+- **Checks #11–#13 (hub promotion/drift/demotion):** use `backlinks` from JSON for counts.
+- **Check #14 (notes inbox):** scoped to `notes/` — read those files directly.
+- **Check #15 (misplaced index entries):** read `wiki/index.md` and linked pages.
+- **Check #16 (trail integrity):** read `wiki/trails/*.md` files.
+
+For checks requiring page reads, use the `scope.scanned_dirs` list from the JSON to avoid reading outside defined scope. Canvas files in `wiki/canvases/` are first-class pages — include them in all checks where `.md` files are checked.
 
 ## Output
 
-Create a lint report at `wiki/meta/lint-report-YYYY-MM-DD.md`.
+Create a lint report at `wiki/meta/lint-report-YYYY-MM-DD.md` per the format in `skills/lint/SKILL.md`.
 
-Use this structure:
-```
-## Summary
-- Pages scanned: N
-- Issues found: N (N critical, N warnings, N suggestions)
-
-## Critical (must fix)
-[dead links, missing required frontmatter]
-
-## Warnings (should fix)
-[orphan pages, stale claims, large pages over 300 lines]
-
-## Suggestions (worth considering)
-[missing pages for frequently mentioned concepts, cross-reference gaps]
-```
-
-List each issue with:
-1. The affected page (wikilink)
-2. The specific problem
-3. A suggested fix
+Include an **Anti-patterns** section for URL-as-wikilink occurrences from `anti_patterns` in the JSON. These are not dead links — report them separately.
 
 Do not auto-fix anything. Report only. The user reviews the report and decides what to fix.

--- a/scripts/lint-scan.sh
+++ b/scripts/lint-scan.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# lint-scan.sh — deterministic lint data producer.
+#
+# Runs a single deterministic pass: invokes obsidian deadends, unresolved,
+# orphans; parses canvas JSON for wikilinks; pre-computes backlinks for every
+# in-scope page. Writes wiki/meta/lint-data-YYYY-MM-DD.json.
+#
+# Two runs on an unchanged vault produce byte-identical output (excluding scan_date).
+# Ordering guarantee: all enumeration arrays are sorted before writing JSON.
+#
+# Usage:
+#   CLAUDE_PLUGIN_ROOT=/path/to/plugin lint-scan.sh
+#
+# Env:
+#   CLAUDE_PLUGIN_ROOT — required; path to this plugin.
+#
+# Exit codes:
+#   0 — success
+#   1 — CLI error or dependency failure
+#   2 — CLAUDE_PLUGIN_ROOT unset
+
+set -euo pipefail
+
+if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  echo "lint-scan: CLAUDE_PLUGIN_ROOT is unset" >&2
+  exit 2
+fi
+command -v jq >/dev/null 2>&1 || { echo "lint-scan: jq is required" >&2; exit 1; }
+
+CLI="${CLAUDE_PLUGIN_ROOT}/scripts/obsidian-cli.sh"
+VAULT="$("${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh")" || {
+  echo "lint-scan: could not resolve vault" >&2; exit 1
+}
+TODAY=$(date +%F)
+OUTPUT_PATH="${VAULT}/wiki/meta/lint-data-${TODAY}.json"
+
+# ─── Scope definition ─────────────────────────────────────────────────────────
+# Single source of truth for what is scanned. Two runs on the same vault state
+# use exactly these inputs and produce the same output.
+
+SCANNED_DIRS=(
+  "wiki/concepts"
+  "wiki/entities"
+  "wiki/sources"
+  "wiki/domains"
+  "wiki/comparisons"
+  "wiki/questions"
+  "wiki/solutions"
+)
+SCANNED_SINGLES=("wiki/index.md" "wiki/log.md" "wiki/hot.md")
+CANVAS_DIR="wiki/canvases"
+
+scope_json=$(jq -n \
+  --argjson scanned_dirs    "$(printf '%s\n' "${SCANNED_DIRS[@]}" | jq -R . | jq -s .)" \
+  --argjson scanned_singles "$(printf '%s\n' "${SCANNED_SINGLES[@]}" | jq -R . | jq -s .)" \
+  --arg     canvas_dir      "$CANVAS_DIR" \
+  --argjson excluded_dirs   '["wiki/meta","wiki/trails","notes","_archive","_templates",".raw"]' \
+  --argjson ext_source      '["md","canvas"]' \
+  --argjson ext_target      '["md","canvas","base","png","jpg","jpeg","svg","pdf"]' \
+  '{
+    scanned_dirs:      $scanned_dirs,
+    scanned_singles:   $scanned_singles,
+    canvas_dir:        $canvas_dir,
+    excluded_dirs:     $excluded_dirs,
+    extensions_source: $ext_source,
+    extensions_target: $ext_target
+  }')
+
+# ─── Enumerate in-scope .md pages (sorted) ────────────────────────────────────
+md_pages=()
+for dir in "${SCANNED_DIRS[@]}"; do
+  while IFS= read -r p; do
+    md_pages+=("$p")
+  done < <(
+    find "${VAULT}/${dir}" -maxdepth 3 -name "*.md" 2>/dev/null \
+      | sed "s|^${VAULT}/||" \
+      | sort
+  )
+done
+for p in "${SCANNED_SINGLES[@]}"; do
+  [[ -f "${VAULT}/${p}" ]] && md_pages+=("$p")
+done
+
+# ─── Unresolved targets (obsidian's resolver is authoritative) ─────────────────
+unresolved_list=()
+while IFS= read -r link; do
+  unresolved_list+=("$link")
+done < <(
+  "$CLI" unresolved format=json 2>/dev/null \
+    | jq -r '.[].link' \
+    | sort -u
+)
+
+declare -A unresolved_set
+for link in "${unresolved_list[@]}"; do
+  unresolved_set["$link"]=1
+done
+
+# ─── Dead links from .md sources ─────────────────────────────────────────────
+# obsidian deadends gives source pages; we read each to find specific broken links.
+
+dead_source_pages=()
+while IFS= read -r p; do
+  dead_source_pages+=("$p")
+done < <(
+  "$CLI" deadends 2>/dev/null \
+    | grep -v '^wiki/trails/' \
+    | grep -v '^wiki/meta/' \
+    | grep -v '^notes/' \
+    | grep -v '^_archive/' \
+    | grep -v '^_templates/' \
+    | sort
+)
+
+dead_links_entries=()
+for source_page in "${dead_source_pages[@]}"; do
+  content=$("$CLI" read "path=${source_page}" 2>/dev/null) || continue
+  while IFS= read -r wikilink; do
+    # Strip pipe-alias: [[Target|Display]] → Target
+    link_target="${wikilink%%|*}"
+    if [[ -n "${unresolved_set[$link_target]+_}" ]]; then
+      dead_links_entries+=(
+        "$(jq -n --arg sp "$source_page" --arg lt "$link_target" \
+             '{source_page: $sp, link_text: $lt}')"
+      )
+    fi
+  done < <(grep -oP '(?<=\[\[)[^\]]+(?=\]\])' <<< "$content" 2>/dev/null | sort -u)
+done
+
+# ─── Canvas dead links and anti-patterns ──────────────────────────────────────
+# Canvas files are JSON; wikilinks live in node text fields. obsidian's CLI
+# verbs (deadends, unresolved) do not cover canvas, so we parse files directly.
+# Documented bypass: canvas JSON requires direct file reads because no structured
+# CLI verb exists for canvas wikilink extraction (see _shared/cli.md §7).
+
+# Build resolver pool from filesystem (basenames without extension).
+# Used only for canvas link verification; .md dead-link checking uses obsidian unresolved.
+declare -A resolver_pool
+while IFS= read -r f; do
+  base=$(basename "$f"); name="${base%.*}"
+  resolver_pool["$name"]=1
+done < <(
+  find "$VAULT" \
+    \( -path "${VAULT}/.obsidian" -prune \) -o \
+    \( -name "*.md" -o -name "*.canvas" -o -name "*.base" \
+       -o -name "*.png" -o -name "*.jpg" -o -name "*.jpeg" \
+       -o -name "*.svg" -o -name "*.pdf" \) -print \
+    2>/dev/null | sort
+)
+
+canvas_dead_entries=()
+canvas_anti_entries=()
+
+if [ -d "${VAULT}/${CANVAS_DIR}" ]; then
+  while IFS= read -r canvas_file; do
+    rel_path="${canvas_file#${VAULT}/}"
+    while IFS= read -r wikilink; do
+      if [[ "$wikilink" =~ ^https?:// ]]; then
+        canvas_anti_entries+=(
+          "$(jq -n --arg sp "$rel_path" --arg lt "$wikilink" \
+               '{source_page: $sp, link_text: $lt}')"
+        )
+      else
+        link_target="${wikilink%%|*}"
+        if [[ -z "${resolver_pool[$link_target]+_}" ]]; then
+          canvas_dead_entries+=(
+            "$(jq -n --arg sp "$rel_path" --arg lt "$link_target" \
+                 '{source_page: $sp, link_text: $lt}')"
+          )
+        fi
+      fi
+    done < <(
+      jq -r '.nodes[]?.text // empty' "$canvas_file" 2>/dev/null \
+        | grep -oP '(?<=\[\[)[^\]]+(?=\]\])' \
+        | sort -u
+    )
+  done < <(find "${VAULT}/${CANVAS_DIR}" -name '*.canvas' 2>/dev/null | sort)
+fi
+
+# ─── Anti-patterns: URL-as-wikilink in .md pages ─────────────────────────────
+md_anti_entries=()
+for page in "${md_pages[@]}"; do
+  content=$("$CLI" read "path=${page}" 2>/dev/null) || continue
+  while IFS= read -r wikilink; do
+    if [[ "$wikilink" =~ ^https?:// ]]; then
+      md_anti_entries+=(
+        "$(jq -n --arg sp "$page" --arg lt "$wikilink" \
+             '{source_page: $sp, link_text: $lt}')"
+      )
+    fi
+  done < <(grep -oP '(?<=\[\[)[^\]]+(?=\]\])' <<< "$content" 2>/dev/null | sort -u)
+done
+
+# ─── Orphans ─────────────────────────────────────────────────────────────────
+orphans_list=()
+while IFS= read -r p; do
+  orphans_list+=("$p")
+done < <(
+  "$CLI" orphans 2>/dev/null \
+    | grep -v '^wiki/trails/' \
+    | grep -v '^notes/' \
+    | grep -v '^wiki/meta/' \
+    | sort
+)
+
+# ─── Backlinks pre-computation ────────────────────────────────────────────────
+# One obsidian CLI call per in-scope page — replaces the ~N in-loop calls
+# the agent previously made during check #10.
+
+scope_pages=("${md_pages[@]}")
+if [ -d "${VAULT}/${CANVAS_DIR}" ]; then
+  while IFS= read -r f; do
+    scope_pages+=("${f#${VAULT}/}")
+  done < <(find "${VAULT}/${CANVAS_DIR}" -name '*.canvas' 2>/dev/null | sort)
+fi
+
+declare -A backlink_counts
+for page in "${scope_pages[@]}"; do
+  count=$("$CLI" backlinks "path=${page}" format=json 2>/dev/null \
+           | jq 'length' 2>/dev/null) || count=0
+  backlink_counts["$page"]="${count:-0}"
+done
+
+# ─── Assemble JSON ────────────────────────────────────────────────────────────
+
+# dead_links: merge .md and canvas entries, sort for determinism
+all_dead=("${dead_links_entries[@]}" "${canvas_dead_entries[@]}")
+if [[ ${#all_dead[@]} -gt 0 ]]; then
+  dead_links_json=$(printf '%s\n' "${all_dead[@]}" \
+    | jq -s 'sort_by(.source_page, .link_text)')
+else
+  dead_links_json='[]'
+fi
+
+if [[ ${#orphans_list[@]} -gt 0 ]]; then
+  orphans_json=$(printf '%s\n' "${orphans_list[@]}" | jq -R . | jq -s '.')
+else
+  orphans_json='[]'
+fi
+
+if [[ ${#unresolved_list[@]} -gt 0 ]]; then
+  unresolved_json=$(printf '%s\n' "${unresolved_list[@]}" | jq -R '{link: .}' | jq -s '.')
+else
+  unresolved_json='[]'
+fi
+
+all_anti=("${md_anti_entries[@]}" "${canvas_anti_entries[@]}")
+if [[ ${#all_anti[@]} -gt 0 ]]; then
+  anti_json=$(printf '%s\n' "${all_anti[@]}" \
+    | jq -s 'sort_by(.source_page, .link_text)')
+else
+  anti_json='[]'
+fi
+
+backlinks_json=$(
+  {
+    for key in $(printf '%s\n' "${!backlink_counts[@]}" | sort); do
+      jq -n --arg k "$key" --argjson v "${backlink_counts[$key]}" '{($k): $v}'
+    done
+  } | jq -s 'add // {}'
+)
+
+# vault commit hash (best-effort)
+vault_commit=""
+if git -C "$VAULT" rev-parse HEAD >/dev/null 2>&1; then
+  vault_commit=$(git -C "$VAULT" rev-parse HEAD 2>/dev/null)
+fi
+
+output=$(jq -n \
+  --arg     scan_date          "$TODAY" \
+  --arg     vault_commit       "$vault_commit" \
+  --argjson scope              "$scope_json" \
+  --argjson dead_links         "$dead_links_json" \
+  --argjson orphans            "$orphans_json" \
+  --argjson unresolved_targets "$unresolved_json" \
+  --argjson anti_patterns      "$anti_json" \
+  --argjson backlinks          "$backlinks_json" \
+  '{
+    scan_date:           $scan_date,
+    vault_commit:        $vault_commit,
+    scope:               $scope,
+    dead_links:          $dead_links,
+    orphans:             $orphans,
+    unresolved_targets:  $unresolved_targets,
+    anti_patterns:       $anti_patterns,
+    backlinks:           $backlinks
+  }')
+
+# Write directly to filesystem — documented bypass: lint-data JSON is administrative
+# bookkeeping (same exception class as .raw/.manifest.json; see _shared/cli.md §6).
+# content= would corrupt embedded \n sequences (see _shared/cli.md §3 escape asymmetry).
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+printf '%s\n' "$output" > "$OUTPUT_PATH"
+
+echo "lint-scan: wrote wiki/meta/lint-data-${TODAY}.json"

--- a/scripts/lint-scan.sh
+++ b/scripts/lint-scan.sh
@@ -135,6 +135,8 @@ done
 
 # Build resolver pool from filesystem (basenames without extension).
 # Used only for canvas link verification; .md dead-link checking uses obsidian unresolved.
+# Pool includes .base as a valid target type (Obsidian Bases files are linkable) but .base
+# files are not scanned for outbound wikilinks — they are data tables, not narrative pages.
 declare -A resolver_pool
 while IFS= read -r f; do
   base=$(basename "$f"); name="${base%.*}"
@@ -174,10 +176,12 @@ if [ -d "${VAULT}/${CANVAS_DIR}" ]; then
         | grep -oP '(?<=\[\[)[^\]]+(?=\]\])' \
         | sort -u
     )
-  done < <(find "${VAULT}/${CANVAS_DIR}" -name '*.canvas' 2>/dev/null | sort)
+  done < <(find "${VAULT}/${CANVAS_DIR}" -name '*.canvas' 2>/dev/null | sort)  # sort: determinism
 fi
 
 # ─── Anti-patterns: URL-as-wikilink in .md pages ─────────────────────────────
+# Anti-patterns are reported per source-page occurrence, not deduplicated across the vault.
+# This matches the dead-links semantics: each broken wikilink is its own finding.
 md_anti_entries=()
 for page in "${md_pages[@]}"; do
   content=$("$CLI" read "path=${page}" 2>/dev/null) || continue

--- a/scripts/lint-verify-consistency.sh
+++ b/scripts/lint-verify-consistency.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# lint-verify-consistency.sh — verify lint scan determinism.
+#
+# Runs lint-scan.sh twice against the current vault and compares the JSON hashes
+# (excluding scan_date, which intentionally differs).  Exits 0 when hashes match,
+# 1 when they diverge, 2 on argument / dependency error.
+#
+# Use as a CI gate: if the vault is unchanged between the two runs, the hashes
+# must be identical.  Divergence indicates non-determinism in lint-scan.sh.
+#
+# Usage:
+#   CLAUDE_PLUGIN_ROOT=/path/to/plugin lint-verify-consistency.sh
+#
+# Exit codes:
+#   0 — consistent (hashes match)
+#   1 — divergent (hashes differ)
+#   2 — dependency error or CLAUDE_PLUGIN_ROOT unset
+
+set -euo pipefail
+
+if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  echo "lint-verify: CLAUDE_PLUGIN_ROOT is unset" >&2
+  exit 2
+fi
+command -v jq        >/dev/null 2>&1 || { echo "lint-verify: jq required" >&2;        exit 2; }
+command -v sha256sum >/dev/null 2>&1 || { echo "lint-verify: sha256sum required" >&2; exit 2; }
+
+SCAN="${CLAUDE_PLUGIN_ROOT}/scripts/lint-scan.sh"
+VAULT="$("${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh")" || {
+  echo "lint-verify: could not resolve vault" >&2; exit 2
+}
+TODAY=$(date +%F)
+DATA_PATH="${VAULT}/wiki/meta/lint-data-${TODAY}.json"
+
+TMP1=$(mktemp)
+TMP2=$(mktemp)
+trap 'rm -f "$TMP1" "$TMP2"' EXIT
+
+echo "lint-verify: run 1..."
+CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" bash "$SCAN" >/dev/null
+cp "$DATA_PATH" "$TMP1"
+
+echo "lint-verify: run 2..."
+CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" bash "$SCAN" >/dev/null
+cp "$DATA_PATH" "$TMP2"
+
+HASH1=$(jq -S 'del(.scan_date)' "$TMP1" | sha256sum | cut -d' ' -f1)
+HASH2=$(jq -S 'del(.scan_date)' "$TMP2" | sha256sum | cut -d' ' -f1)
+
+echo "run 1: $HASH1"
+echo "run 2: $HASH2"
+
+if [ "$HASH1" = "$HASH2" ]; then
+  echo "lint-verify: OK — hashes match"
+  exit 0
+else
+  echo "lint-verify: FAIL — hashes diverge" >&2
+  echo "diff (excluding scan_date):" >&2
+  diff <(jq -S 'del(.scan_date)' "$TMP1") <(jq -S 'del(.scan_date)' "$TMP2") >&2 || true
+  exit 1
+fi

--- a/scripts/prune-lint-reports.sh
+++ b/scripts/prune-lint-reports.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
-# prune-lint-reports.sh — keep the most recent N lint reports in wiki/meta/.
+# prune-lint-reports.sh — keep the most recent N lint artifacts in wiki/meta/.
 #
-# Each lint run writes wiki/meta/lint-report-YYYY-MM-DD.md. Old reports
-# accumulate, clutter wiki/meta/, and inflate git diffs even though they're
-# advisory: the dashboard already carries the latest summary and each new
-# report subsumes the previous findings. This script prunes everything
-# beyond the top KEEP reports by ISO date.
+# Each lint run writes two files:
+#   wiki/meta/lint-report-YYYY-MM-DD.md   — human-readable report
+#   wiki/meta/lint-data-YYYY-MM-DD.json   — canonical machine-readable data
+#
+# Old artifacts accumulate, clutter wiki/meta/, and inflate git diffs even
+# though they're advisory: the dashboard already carries the latest summary and
+# each new report subsumes the previous findings. This script prunes everything
+# beyond the top KEEP artifacts by ISO date (same KEEP applied to both types).
 #
 # Usage:
 #   prune-lint-reports.sh            # default keep=3
@@ -36,12 +39,18 @@ fi
 CLI="${CLAUDE_PLUGIN_ROOT}/scripts/obsidian-cli.sh"
 SKIP=$((KEEP + 1))
 
-# ISO-8601 dates sort lexically; sort -r puts newest first; tail -n +SKIP
-# emits everything past the top KEEP.
-"$CLI" files dir=wiki/meta format=json \
-  | jq -r '.[] | select(.path | test("^wiki/meta/lint-report-[0-9]{4}-[0-9]{2}-[0-9]{2}\\.md$")) | .path' \
-  | sort -r \
-  | tail -n "+$SKIP" \
-  | while read -r stale; do
-      "$CLI" delete path="$stale"
-    done
+prune_pattern() {
+  local pattern="$1"
+  # ISO-8601 dates sort lexically; sort -r puts newest first; tail -n +SKIP
+  # emits everything past the top KEEP.
+  "$CLI" files dir=wiki/meta format=json \
+    | jq -r --arg pat "$pattern" '.[] | select(.path | test($pat)) | .path' \
+    | sort -r \
+    | tail -n "+$SKIP" \
+    | while read -r stale; do
+        "$CLI" delete path="$stale"
+      done
+}
+
+prune_pattern '^wiki/meta/lint-report-[0-9]{4}-[0-9]{2}-[0-9]{2}\\.md$'
+prune_pattern '^wiki/meta/lint-data-[0-9]{4}-[0-9]{2}-[0-9]{2}\\.json$'

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -119,6 +119,7 @@ Steps:
 3. **Create** source summary in `wiki/sources/`. Use the source frontmatter schema from `${CLAUDE_PLUGIN_ROOT}/_shared/frontmatter.md`.
 4. **Create or update** entity pages for every person, org, product, and repo mentioned. One page per entity.
 5. **Create or update** concept pages for significant ideas and frameworks.
+   When checking for existing pages to link against, include canvas files in `wiki/canvases/` — they are first-class wiki pages. The ingest skill itself creates `.md` pages; canvas creation is done by the `canvas` skill.
 6. **Update** relevant domain hubs at `wiki/domains/<slug>/_index.md` if any new leaves match an existing hub's tag — append the new leaves to the hub's `related:` list and bump the hub's `page_count:`. Do not write a `domain:` field on the leaves.
 7. **Update** `wiki/index.md`. Add entries for all new pages.
 8. **Update** `wiki/hot.md` with this ingest's context.

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -14,18 +14,70 @@ Run lint after every 10-15 ingests, or weekly. Ask before auto-fixing anything. 
 
 ---
 
+## Scan Scope
+
+The deterministic scan script (`scripts/lint-scan.sh`) uses this scope. Two runs on an unchanged vault produce byte-identical JSON (excluding `scan_date`).
+
+**Folders scanned:**
+- `wiki/concepts/`, `wiki/entities/`, `wiki/sources/`, `wiki/domains/`, `wiki/comparisons/`, `wiki/questions/`, `wiki/solutions/`
+- `wiki/index.md`, `wiki/log.md`, `wiki/hot.md`
+- `wiki/canvases/*.canvas` — first-class; treated identically to `.md` in all 16 checks
+
+**Folders excluded (with rationale):**
+- `wiki/meta/` — administrative bookkeeping (lint reports, dashboards). Findings pointing into `wiki/meta/` from `wiki/index.md` are still validated by check #15.
+- `wiki/trails/` — frozen run-snapshots; surfaced for visibility, never counted toward totals, never auto-fixed.
+- `notes/` — transient inbox; only checks #14 (frontmatter gaps) and index drift apply.
+- `_archive/`, `_templates/`, `.raw/` — non-wiki storage; never scanned.
+
+**File extensions scanned for wikilinks (sources):** `.md`, `.canvas`
+
+**File extensions valid as wikilink targets (resolver pool):** `.md`, `.canvas`, `.base`, `.png`, `.jpg`, `.jpeg`, `.svg`, `.pdf`
+
+**Ordering guarantee:** `lint-scan.sh` sorts all enumerations before writing JSON.
+
+---
+
+## Repeatability Check
+
+Run this recipe after any change to the scan script or lint agent to verify determinism:
+
+```bash
+# Run twice on an unchanged vault
+CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}" \
+  bash "${CLAUDE_PLUGIN_ROOT}/scripts/lint-verify-consistency.sh"
+```
+
+The script calls `lint-scan.sh` twice and compares SHA-256 hashes of the JSON output (excluding `scan_date`). Hashes must match; divergence indicates non-determinism.
+
+Manual verification:
+```bash
+CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}" bash "${CLAUDE_PLUGIN_ROOT}/scripts/lint-scan.sh"
+cp "${VAULT}/wiki/meta/lint-data-$(date +%F).json" /tmp/lint-data-1.json
+
+CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}" bash "${CLAUDE_PLUGIN_ROOT}/scripts/lint-scan.sh"
+cp "${VAULT}/wiki/meta/lint-data-$(date +%F).json" /tmp/lint-data-2.json
+
+# Hashes must match (excluding scan_date)
+jq -S 'del(.scan_date)' /tmp/lint-data-1.json | sha256sum
+jq -S 'del(.scan_date)' /tmp/lint-data-2.json | sha256sum
+```
+
+---
+
 ## Lint Checks
 
-Use the native `obsidian` CLI verbs for efficient data gathering:
-- Orphan pages: `obsidian orphans` (returns one path per line)
-- Dead links: `obsidian deadends` (returns one path per line)
+The lint agent (`agents/lint.md`) runs `scripts/lint-scan.sh` first to produce `wiki/meta/lint-data-YYYY-MM-DD.json`. Checks #1, #2, and #10 read directly from that JSON; the remaining checks use the native `obsidian` CLI verbs or page reads as noted below.
+
+When invoking CLI verbs directly (checks #3–#9, #11–#16):
+- Inbound links per page: `obsidian backlinks path=<page> format=json` (returns `[{"file": "<path>"}]`; count entries for the inbound-link count) — only needed if the JSON backlinks map is not available.
 - Unresolved links: `obsidian unresolved format=json` (returns `[{"link": "..."}]`)
-- Inbound links per page: `obsidian backlinks path=<page> format=json` (returns `[{"file": "<path>"}]`; count entries for the inbound-link count)
 
 Work through these in order:
 
-1. **Orphan pages**. Use `obsidian orphans` to enumerate. Wiki pages with no inbound wikilinks. They exist but nothing points to them. **Exclude `wiki/trails/*.md`** from this check — trails are designed-orphan: the synthesis page does not link back to them (forward-only model), so every trail would be flagged as orphan in perpetuity.
-2. **Dead links**. Use `obsidian deadends` to enumerate. Wikilinks that reference a page that does not exist. Findings inside `wiki/trails/*.md` are surfaced for visibility but **never auto-fixed** — trails are run-snapshots frozen at write time; the user repairs manually or accepts the drift (same policy as check #16).
+1. **Orphan pages**. Source: `orphans` array in `lint-data-YYYY-MM-DD.json`. Wiki pages (`.md` and `.canvas`) with no inbound wikilinks. They exist but nothing points to them. `wiki/trails/*.md` and `notes/` are already excluded from the JSON output — trails are designed-orphan (forward-only model), so they would be flagged in perpetuity.
+2. **Dead links**. Source: `dead_links` array in `lint-data-YYYY-MM-DD.json`. Each entry is `{source_page, link_text}` — a wikilink in `source_page` that does not resolve to any existing page. Canvas dead links are merged into the same array; no separate handling. Findings inside `wiki/trails/*.md` are surfaced for visibility but **never auto-fixed** — trails are run-snapshots frozen at write time; the user repairs manually or accepts the drift (same policy as check #16).
+
+    **Anti-pattern note:** URL-as-wikilink occurrences (e.g. `[[https://...]]`) are in the `anti_patterns` array of the JSON. Report these in a dedicated **Anti-patterns** section; do **not** count them toward the dead-link total.
 3. **Stale claims**. Assertions on older pages that newer sources have contradicted or updated.
 4. **Missing pages**. Concepts or entities mentioned in multiple pages but lacking their own page.
 5. **Missing cross-references**. Entities mentioned in a page but not linked.
@@ -36,7 +88,7 @@ Work through these in order:
    - **WARN** if word count > 500 (spec limit per `_shared/hot-cache-protocol.md`).
    - **FAIL** if word count > 750 (50 % buffer exceeded).
    - Remediation: move entries older than 2 weeks to `wiki/log.md`; trim `## Last Updated` to the 3–5 most recent items.
-10. **Backlink density**. For every page under `wiki/` (skip `wiki/meta/` and `notes/`), compute the inbound count via `obsidian backlinks path=<page>` and the outbound count from the page's frontmatter `related:` length plus inline wikilinks. Flag pages where `inbound ≥ 3` **and** `outbound ≤ 1` — heavily cited but weakly linking. These pages are retrieval-late under the forward-only `related:` model, so surfacing them prompts targeted cross-linking. Compute on demand; no backlink index is persisted.
+10. **Backlink density**. Source: `backlinks` map in `lint-data-YYYY-MM-DD.json` (pre-computed by `lint-scan.sh`; do **not** call `obsidian backlinks` per page). For every in-scope page (`.md` and `.canvas`, per the scope definition above), use the precomputed inbound count and compare against the outbound count from the page's frontmatter `related:` length plus inline wikilinks. Flag pages where `inbound ≥ 3` **and** `outbound ≤ 1` — heavily cited but weakly linking. These pages are retrieval-late under the forward-only `related:` model, so surfacing them prompts targeted cross-linking.
 11. **Hub promotion candidates**. Group all leaves under `wiki/concepts/`, `wiki/entities/`, `wiki/solutions/`, `wiki/sources/` by their primary tag (the first non-type tag in `tags:`). For each tag-cluster of **≥ 10 leaves**, check whether `wiki/domains/<cluster-tag>/_index.md` exists. If it does not, surface the cluster as a **promotion candidate** — recommend running `/wiki promote <tag>` to scaffold a domain hub. Threshold rationale: clusters below ~10 leaves are noisy; LYT MOC heuristics put the mental-squeeze trigger around this size.
 12. **Hub stale-count drift**. For every `wiki/domains/<slug>/_index.md`, compare the hub's frontmatter `page_count:` to the actual inbound count returned by `obsidian backlinks path=wiki/domains/<slug>/_index.md format=json`. Flag drift **> 20 %** (in either direction). Suggest resync — either update `page_count:` to the live count or re-curate the `related:` list to match reality.
 13. **Hub demotion candidates**. For every `wiki/domains/<slug>/_index.md`, count the leaves linked from the hub's `related:` field. If **< 5**, surface the hub as a **demotion candidate** — its cluster is below the hub-worthwhile threshold and the hub may be churn rather than signal. Recommend either growing the cluster or merging the hub into a sibling.
@@ -154,6 +206,13 @@ Scope: `wiki/trails/*.md`. Run-record snapshots; never auto-fixed.
 - `[[Trail: Topic (YYYY-MM-DD)]]`: synthesis link `[[Research: Topic]]` does not resolve.
 - `[[Trail: Topic (YYYY-MM-DD)]]`: body is not an ordered list (found: <prose paragraph | nested list | multiple top-level lists | no list>).
 - `[[Trail: Topic (YYYY-MM-DD)]]`: step N has <no wikilink | multiple wikilinks | no annotation | URL in annotation | extra wikilink in annotation>.
+
+## Anti-patterns
+
+Source: `anti_patterns` array from `wiki/meta/lint-data-YYYY-MM-DD.json`.
+Not counted toward dead-link total. Each entry is `[[https://...]]` used as a wikilink.
+
+- `[[Source Page]]`: URL-as-wikilink `[[https://example.com]]`. Suggest: convert to a plain `[text](url)` Markdown link.
 ```
 
 ---
@@ -296,10 +355,10 @@ If the lint report is advisory only (no auto-fixes applied), skip the hot.md upd
 
 ## Report Rotation
 
-After writing the new report, prune older ones:
+After writing the new report, prune older lint artifacts (both `.md` reports and `.json` data files):
 
 ```bash
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/prune-lint-reports.sh"
 ```
 
-See the script header for keep-count, override arg, and rationale.
+The script keeps the most recent 3 of each artifact type by default. Pass a count to override (`prune-lint-reports.sh 5`). See the script header for rationale.

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -33,13 +33,6 @@ The deterministic scan script (`scripts/lint-scan.sh`) uses this scope. Two runs
 
 **File extensions valid as wikilink targets (resolver pool):** `.md`, `.canvas`, `.base`, `.png`, `.jpg`, `.jpeg`, `.svg`, `.pdf`
 
-**Ordering guarantee:** `lint-scan.sh` sorts all enumerations before writing JSON.
-
-**Edge case handling:**
-- **Canvas (`.canvas`) files** — treated as first-class documents; identical handling to `.md` in all 16 checks.
-- **URL-as-wikilink** (e.g. `[[https://...]]`) — flagged as `anti_patterns` in the JSON, rendered in a dedicated **Anti-patterns** section of the report. Not counted toward the dead-link total.
-- **Alias resolution** — `lint-scan.sh` relies on `obsidian unresolved`, which respects `aliases:` frontmatter. A wikilink that resolves via an alias is not a dead link. A wikilink that matches neither a filename nor any page's `aliases:` entry is a real dead link — no "title-mismatch" soft category.
-
 ---
 
 ## Lint Checks

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -42,33 +42,6 @@ The deterministic scan script (`scripts/lint-scan.sh`) uses this scope. Two runs
 
 ---
 
-## Repeatability Check
-
-Run this recipe after any change to the scan script or lint agent to verify determinism:
-
-```bash
-# Run twice on an unchanged vault
-CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}" \
-  bash "${CLAUDE_PLUGIN_ROOT}/scripts/lint-verify-consistency.sh"
-```
-
-The script calls `lint-scan.sh` twice and compares SHA-256 hashes of the JSON output (excluding `scan_date`). Hashes must match; divergence indicates non-determinism.
-
-Manual verification:
-```bash
-CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}" bash "${CLAUDE_PLUGIN_ROOT}/scripts/lint-scan.sh"
-cp "${VAULT}/wiki/meta/lint-data-$(date +%F).json" /tmp/lint-data-1.json
-
-CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}" bash "${CLAUDE_PLUGIN_ROOT}/scripts/lint-scan.sh"
-cp "${VAULT}/wiki/meta/lint-data-$(date +%F).json" /tmp/lint-data-2.json
-
-# Hashes must match (excluding scan_date)
-jq -S 'del(.scan_date)' /tmp/lint-data-1.json | sha256sum
-jq -S 'del(.scan_date)' /tmp/lint-data-2.json | sha256sum
-```
-
----
-
 ## Lint Checks
 
 The lint agent (`agents/lint.md`) runs `scripts/lint-scan.sh` first to produce `wiki/meta/lint-data-YYYY-MM-DD.json`. Checks #1, #2, and #10 read directly from that JSON; the remaining checks use the native `obsidian` CLI verbs or page reads as noted below.

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -35,6 +35,11 @@ The deterministic scan script (`scripts/lint-scan.sh`) uses this scope. Two runs
 
 **Ordering guarantee:** `lint-scan.sh` sorts all enumerations before writing JSON.
 
+**Edge case handling:**
+- **Canvas (`.canvas`) files** — treated as first-class documents; identical handling to `.md` in all 16 checks.
+- **URL-as-wikilink** (e.g. `[[https://...]]`) — flagged as `anti_patterns` in the JSON, rendered in a dedicated **Anti-patterns** section of the report. Not counted toward the dead-link total.
+- **Alias resolution** — `lint-scan.sh` relies on `obsidian unresolved`, which respects `aliases:` frontmatter. A wikilink that resolves via an alias is not a dead link. A wikilink that matches neither a filename nor any page's `aliases:` entry is a real dead link — no "title-mismatch" soft category.
+
 ---
 
 ## Repeatability Check

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -28,6 +28,8 @@ Two top-level peers of `wiki/`:
 - `notes/` — verbatim quick-capture inbox owned by the `notes` skill.
 - `daily/` — append-only daily log owned by the `daily` skill.
 
+**Canvas files** (`wiki/canvases/*.canvas`) are first-class wiki documents. They are indexed in `wiki/index.md`, counted toward page totals in lint, scanned for dead wikilinks, and included in backlink calculations. When any skill enumerates wiki pages, `.canvas` files in `wiki/canvases/` are valid pages alongside `.md` files in the concept/entity/source directories. The `canvas` skill owns creation and editing of these files.
+
 Dot-prefixed folders (`.raw/`) are hidden in Obsidian's file explorer and graph view. Use this for source documents.
 
 ---


### PR DESCRIPTION
Closes #100

## Summary
- Replace agent-driven enumeration (Sonnet, maxTurns: 40) with deterministic `scripts/lint-scan.sh` that produces a canonical JSON snapshot at `wiki/meta/lint-data-YYYY-MM-DD.json`. Agent now reads JSON for orphans/dead-links/backlinks instead of re-discovering them each run.
- Lock scope explicitly in `skills/lint/SKILL.md` (folders, extensions, exclusions with rationale) and document canvas files as first-class wiki pages across `skills/wiki/SKILL.md`, `skills/ingest/SKILL.md`, and `_shared/cli.md` §7.
- Add `scripts/lint-verify-consistency.sh` CI gate: runs the scan twice and compares SHA-256 hashes (excluding `scan_date`); exits non-zero on divergence.

## Test plan
- [x] AC1: Two consecutive `lint-scan.sh` runs on an unchanged vault produce byte-identical JSON (verified via `lint-verify-consistency.sh`).
- [x] AC2: Scope explicitly documented — folders scanned, extensions, and exclusions with rationale present in `skills/lint/SKILL.md`.
- [x] AC3: Canvas files counted in dead-link and orphan checks; resolver pool built from `find` over `*.md` + `*.canvas` + `*.base`.
- [x] AC4: Alias-resolution edge case documented — wikilinks matching neither filename nor `aliases:` entry are real dead links.
- [x] AC5: Report rotation prunes both `lint-report-*.md` and `lint-data-*.json` (KEEP=3 default).

## Manual testing
1. Check out the branch and \`cd\` into a worktree containing this vault.
2. Run \`bash scripts/lint-scan.sh\` twice in succession — both invocations should produce a JSON file at \`wiki/meta/lint-data-\$(date +%F).json\` with identical content modulo the \`scan_date\` field.
3. Run \`bash scripts/lint-verify-consistency.sh\` — exits 0 with \`Hashes match — lint-scan.sh is deterministic\`. Mutate a wiki page in-flight to confirm it exits 1 with a unified diff on divergence.
4. Run the \`/lint\` skill and confirm the report cites \`wiki/meta/lint-data-*.json\` for orphan/dead-link/backlink counts and that anti-pattern detection (URL-as-wikilink) appears in the report's new section.
5. Run \`bash scripts/prune-lint-reports.sh\` after multiple days of scans and confirm both \`lint-report-*.md\` and \`lint-data-*.json\` are pruned to the latest 3.