### PR TITLE
fix(obsidian-cli): pass vault= after verb, not before

### DIFF
--- a/scripts/obsidian-cli.sh
+++ b/scripts/obsidian-cli.sh
@@ -126,7 +126,7 @@ fi
 run_obs() {
   local tmp first cli_exit
   tmp="$(mktemp)"
-  obsidian "vault=$VAULT_NAME" "$@" >"$tmp" 2>&2
+  obsidian "$@" "vault=$VAULT_NAME" >"$tmp" 2>&2
   cli_exit=$?
   cat "$tmp"
   first="$(head -n 1 "$tmp" 2>/dev/null || true)"
@@ -163,7 +163,7 @@ do_create_or_append() {
   # into memory just to learn whether the file exists.
   local append_out append_first append_rc
   append_out="$(mktemp)"
-  obsidian "vault=$VAULT_NAME" append "file=$file" "content=$content" \
+  obsidian append "file=$file" "content=$content" "vault=$VAULT_NAME" \
     >"$append_out" 2>&2
   append_rc=$?
   append_first="$(head -n 1 "$append_out" 2>/dev/null || true)"
@@ -298,7 +298,7 @@ esac
 TMP_OUT="$(mktemp)"
 trap 'rm -f "$TMP_OUT"' EXIT
 
-obsidian "vault=$VAULT_NAME" "$@" >"$TMP_OUT" 2>&2
+obsidian "$@" "vault=$VAULT_NAME" >"$TMP_OUT" 2>&2
 CLI_EXIT=$?
 
 # 5. Pass stdout through to the caller verbatim.


### PR DESCRIPTION
## Context

The upstream Obsidian CLI requires the verb as its first positional argument. \`obsidian-cli.sh\` was passing \`vault=\$VAULT_NAME\` before the verb in all three call sites:

\`\`\`bash
# before (broken)
obsidian "vault=$VAULT_NAME" "$@"
obsidian "vault=$VAULT_NAME" append "file=$file" "content=$content"

# after (fixed)
obsidian "$@" "vault=$VAULT_NAME"
obsidian append "file=$file" "content=$content" "vault=$VAULT_NAME"
\`\`\`

This caused every wrapper-mediated vault operation to return \`Vault not found.\` even when the vault name was correct and Obsidian was running. Skills that call the wrapper directly (\`/save\`, \`/daily\`, \`/ingest\`, \`index-section-insert.sh\`, \`create-or-append\`, etc.) were all broken. Calling the binary directly with the verb first worked fine, confirming argument order as the root cause.

Three sites fixed: \`run_obs()\` (line 129), the \`create-or-append\` append fast-path (line 166), and the main verb dispatch (line 301).

## Testing

With the fix applied and a vault configured via \`pluginConfigs.vault_path\`:

\`\`\`bash
bash scripts/obsidian-cli.sh read path=wiki/hot.md   # should return file contents
bash scripts/obsidian-cli.sh read path=wiki/index.md # should return file contents
\`\`\`

Before the fix both returned \`Vault not found.\` Despite the vault name resolving correctly via \`resolve-vault.sh\`.