### PR TITLE
fix(lint-scan): handle empty backlinks output before piping to jq

### DIFF
--- a/scripts/lint-scan.sh
+++ b/scripts/lint-scan.sh
@@ -220,8 +220,8 @@ fi
 
 declare -A backlink_counts
 for page in "${scope_pages[@]}"; do
-  count=$("$CLI" backlinks "path=${page}" format=json 2>/dev/null \
-           | jq 'length' 2>/dev/null) || count=0
+  raw=$("$CLI" backlinks "path=${page}" format=json 2>/dev/null) || true
+  count=$(jq 'length' <<< "${raw:-[]}" 2>/dev/null) || count=0
   backlink_counts["$page"]="${count:-0}"
 done
 


### PR DESCRIPTION
## Context

When the Obsidian CLI returns empty output (rather than `[]`) for a page's backlinks, the original code piped that empty stream directly to `jq 'length'`, which failed with a parse error. The `|| count=0` guard is not reliably reached because `set -o pipefail` can propagate the jq non-zero exit differently across bash versions.

## Acceptance Criteria

- `lint-scan.sh` completes without error on vaults that have pages returning empty backlink output.
- Pages with no backlinks get a count of `0` in the output JSON (unchanged semantics).

## Testing

The fix separates the CLI call from jq: capture the raw CLI output first, then default to `[]` before handing off to jq. To verify manually:

```bash
# Simulate empty backlinks response
raw=""
jq 'length' <<< "${raw:-[]}"   # should print 0
```

Run the existing smoke tests to confirm no regression:
```bash
bash tests/cli-smoke.sh
```