### PR TITLE
chore(lint/skills): demote checks #3–#5 to manual, trim skill descriptions

### DIFF
--- a/agents/lint.md
+++ b/agents/lint.md
@@ -1,10 +1,9 @@
 ---
 name: lint
 description: >
-  Comprehensive wiki health check agent. Scans for orphan pages, dead links, stale claims,
-  missing cross-references, frontmatter gaps, and empty sections. Generates a structured
-  lint report. Dispatched when the user says "lint the wiki", "health check", "wiki audit",
-  or "clean up".
+  Comprehensive wiki health check agent. Scans for orphan pages, dead links, frontmatter
+  gaps, and empty sections. Generates a structured lint report. Dispatched when the user
+  says "lint the wiki", "health check", "wiki audit", or "clean up".
   <example>Context: User says "lint the wiki" after 15 ingests
   assistant: "I'll dispatch the lint agent for a full health check."
   </example>
@@ -48,9 +47,6 @@ After reading the JSON, perform the checks that require reading page content or 
 
 - **Check #1 (orphans):** use `orphans` from JSON.
 - **Check #2 (dead links):** use `dead_links` from JSON. Canvas dead links are already merged in.
-- **Check #3 (stale claims):** requires reading pages — do this yourself.
-- **Check #4 (missing pages):** requires reading pages — do this yourself.
-- **Check #5 (missing cross-references):** requires reading pages — do this yourself.
 - **Check #6 (frontmatter gaps):** read each in-scope page; use `scope.scanned_dirs` from JSON for the exact directory list.
 - **Check #7 (empty sections):** requires reading pages.
 - **Check #8 (stale index entries):** use `obsidian read path=wiki/index.md` then validate each link.

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: autoresearch
-description: >
-  Autonomous iterative research loop. Takes a topic, runs web searches, fetches sources,
-  synthesizes findings, and files everything into the wiki as structured pages.
-  Based on Karpathy's autoresearch pattern: program.md configures objectives and constraints,
-  the loop runs until depth is reached, output goes directly into the knowledge base.
-  Triggers on: "/autoresearch", "autoresearch", "research [topic]", "deep dive into [topic]",
-  "investigate [topic]", "find everything about [topic]", "research and file",
-  "go research", "build a wiki on".
+description: Autonomous research loop. Searches the web, synthesizes findings, and files structured wiki pages.
 allowed-tools: Bash Read Glob Grep WebFetch WebSearch
 ---
 

--- a/skills/braindump/SKILL.md
+++ b/skills/braindump/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: braindump
-description: >
-  Split a long-form text stream into atomic thoughts and file each as a
-  separate inbox note — without breaking flow. Accepts inline text or a
-  file path (vault-relative or absolute). Each chunk goes through the full
-  CAPTURE pipeline (MATCH/NEW per chunk). Triage later via /note process.
-  Triggers on: "/braindump", "brain dump this", "dump the following thoughts",
-  "dump these thoughts", "braindump:", "split this into notes".
+description: Split long-form text into atomic inbox notes. Accepts inline text or file paths. Triage later via /note process.
 allowed-tools: Bash Read Glob Grep
 ---
 

--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: canvas
-description: "Visual layer of the wiki. Add images, text cards, PDFs, and wiki pages to Obsidian canvas files with auto-positioning inside zones. Integrates with /banana for image capture. Triggers on: /canvas, canvas new, canvas add image, canvas add text, canvas add pdf, canvas add note, canvas zone, canvas list, canvas from banana, add to canvas, put this on the canvas, open canvas, create canvas."
+description: "Visual layer of the wiki. Add images, text cards, PDFs, and wiki pages to canvas files with zones. Integrates with /banana."
 allowed-tools: Bash Read Glob Grep
 ---
 

--- a/skills/daily-close/SKILL.md
+++ b/skills/daily-close/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: daily-close
-description: >
-  Synthesize a day's full capture record into a polished prose summary with
-  optional follow-ups, appended to the daily file. Reads the daily log,
-  date-matched inbox notes, date-matched wiki pages, hot cache, and index.
-  Synthesis only — does not triage or clear the inbox.
-  Triggers on: "/daily-close", "close today", "wrap up today", "synthesize today".
+description: "Synthesize a day's captures into a prose summary appended to the daily file. Reads log, inbox notes, wiki pages, and hot cache."
 allowed-tools: Bash Read Glob
 ---
 

--- a/skills/daily/SKILL.md
+++ b/skills/daily/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: daily
-description: >
-  Append a timestamped bullet to today's daily log in the vault. Each call
-  adds one line to <vault_root>/daily/YYYY-MM-DD.md — no inbox, no triage.
-  Triggers on: "/daily", "daily note this", "log to today", "log this",
-  "add to today's log", "daily log:".
+description: "Append a timestamped bullet to today's daily log. No inbox, no triage — one line per call."
 allowed-tools: Bash Read Glob
 ---
 

--- a/skills/defuddle/SKILL.md
+++ b/skills/defuddle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: defuddle
-description: "Strip clutter from web pages before ingesting into the wiki. Removes ads, navigation, headers, footers, and boilerplate: leaving clean readable markdown that saves 40-60% tokens. Triggers on: defuddle, clean this page, strip this url, fetch and clean, clean web content before ingesting, strip ads, remove clutter, clean URL content, readable markdown from URL."
+description: Strip clutter from web pages before ingesting. Removes ads, navigation, and boilerplate — leaving clean markdown that saves 40-60% tokens.
 allowed-tools: Read Bash
 ---
 

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ingest
-description: "Ingest sources into the Obsidian wiki vault. Reads a source, extracts entities and concepts, creates or updates wiki pages, cross-references, and logs the operation. Supports files, URLs, and batch mode. Triggers on: ingest, process this source, add this to the wiki, read and file this, batch ingest, ingest all of these, ingest this url."
+description: Ingest sources into the wiki vault. Extracts entities and concepts, creates or updates wiki pages, and cross-references them. Supports files and URLs.
 allowed-tools: Bash Read Glob Grep WebFetch
 ---
 

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lint
-description: Health check the wiki vault. Finds orphans, dead wikilinks, stale claims, and frontmatter gaps. Generates canvas maps and Bases dashboards.
+description: Health check the wiki vault. Finds orphans, dead wikilinks, and frontmatter gaps. Generates canvas maps and Bases dashboards.
 allowed-tools: Bash Read Glob Grep
 ---
 
@@ -15,11 +15,13 @@ Run lint after every 10-15 ingests, or weekly. Ask before auto-fixing anything. 
 The deterministic scan script (`scripts/lint-scan.sh`) uses this scope. Two runs on an unchanged vault produce byte-identical JSON (excluding `scan_date`).
 
 **Folders scanned:**
+
 - `wiki/concepts/`, `wiki/entities/`, `wiki/sources/`, `wiki/domains/`, `wiki/comparisons/`, `wiki/questions/`, `wiki/solutions/`
 - `wiki/index.md`, `wiki/log.md`, `wiki/hot.md`
 - `wiki/canvases/*.canvas` — first-class; treated identically to `.md` in all 16 checks
 
 **Folders excluded (with rationale):**
+
 - `wiki/meta/` — administrative bookkeeping (lint reports, dashboards). Findings pointing into `wiki/meta/` from `wiki/index.md` are still validated by check #15.
 - `wiki/trails/` — frozen run-snapshots; surfaced for visibility, never counted toward totals, never auto-fixed.
 - `notes/` — transient inbox; only checks #14 (frontmatter gaps) and index drift apply.
@@ -36,58 +38,59 @@ The deterministic scan script (`scripts/lint-scan.sh`) uses this scope. Two runs
 The lint agent (`agents/lint.md`) runs `scripts/lint-scan.sh` first to produce `wiki/meta/lint-data-YYYY-MM-DD.json`. Checks #1, #2, and #10 read directly from that JSON; the remaining checks use the native `obsidian` CLI verbs or page reads as noted below.
 
 When invoking CLI verbs directly (checks #6–#9, #11–#16):
+
 - Inbound links per page: `obsidian backlinks path=<page> format=json` (returns `[{"file": "<path>"}]`; count entries for the inbound-link count) — only needed if the JSON backlinks map is not available.
 - Unresolved links: `obsidian unresolved format=json` (returns `[{"link": "..."}]`)
 
 Work through these in order:
 
-1. **Orphan pages**. Source: `orphans` array in `lint-data-YYYY-MM-DD.json`. Wiki pages (`.md` and `.canvas`) with no inbound wikilinks. They exist but nothing points to them. `wiki/trails/*.md` and `notes/` are already excluded from the JSON output — trails are designed-orphan (forward-only model), so they would be flagged in perpetuity.
-2. **Dead links**. Source: `dead_links` array in `lint-data-YYYY-MM-DD.json`. Each entry is `{source_page, link_text}` — a wikilink in `source_page` that does not resolve to any existing page. Canvas dead links are merged into the same array; no separate handling. Findings inside `wiki/trails/*.md` are surfaced for visibility but **never auto-fixed** — trails are run-snapshots frozen at write time; the user repairs manually or accepts the drift (same policy as check #16).
+- **Check #1: Orphan pages**. Source: `orphans` array in `lint-data-YYYY-MM-DD.json`. Wiki pages (`.md` and `.canvas`) with no inbound wikilinks. They exist but nothing points to them. `wiki/trails/*.md` and `notes/` are already excluded from the JSON output — trails are designed-orphan (forward-only model), so they would be flagged in perpetuity.
+- **Check #2: Dead links**. Source: `dead_links` array in `lint-data-YYYY-MM-DD.json`. Each entry is `{source_page, link_text}` — a wikilink in `source_page` that does not resolve to any existing page. Canvas dead links are merged into the same array; no separate handling. Findings inside `wiki/trails/*.md` are surfaced for visibility but **never auto-fixed** — trails are run-snapshots frozen at write time; the user repairs manually or accepts the drift (same policy as check #16).
 
-    **Anti-pattern note:** URL-as-wikilink occurrences (e.g. `[[https://...]]`) are in the `anti_patterns` array of the JSON. Report these in a dedicated **Anti-patterns** section; do **not** count them toward the dead-link total.
-6. **Frontmatter gaps**. Pages missing required fields (`type`, `status`, `created`, `updated`, `tags`, `confidence`). Additionally, flag missing `evidence:` when `confidence:` is `INFERRED` or `AMBIGUOUS` (per `_shared/frontmatter.md` rule 7 — `evidence:` is required for those confidence levels).
-7. **Empty sections**. Headings with no content underneath.
-8. **Stale index entries**. Items in `wiki/index.md` pointing to renamed or deleted pages.
-9. **hot.md size budget**. Count words in `wiki/hot.md`.
-   - **WARN** if word count > 500 (spec limit per `_shared/hot-cache-protocol.md`).
-   - **FAIL** if word count > 750 (50 % buffer exceeded).
-   - Remediation: move entries older than 2 weeks to `wiki/log.md`; trim `## Last Updated` to the 3–5 most recent items.
-10. **Backlink density**. Source: `backlinks` map in `lint-data-YYYY-MM-DD.json` (pre-computed by `lint-scan.sh`; do **not** call `obsidian backlinks` per page). For every in-scope page (`.md` and `.canvas`, per the scope definition above), use the precomputed inbound count and compare against the outbound count from the page's frontmatter `related:` length plus inline wikilinks. Flag pages where `inbound ≥ 3` **and** `outbound ≤ 1` — heavily cited but weakly linking. These pages are retrieval-late under the forward-only `related:` model, so surfacing them prompts targeted cross-linking.
-11. **Hub promotion candidates**. Group all leaves under `wiki/concepts/`, `wiki/entities/`, `wiki/solutions/`, `wiki/sources/` by their primary tag (the first non-type tag in `tags:`). For each tag-cluster of **≥ 10 leaves**, check whether `wiki/domains/<cluster-tag>/_index.md` exists. If it does not, surface the cluster as a **promotion candidate** — recommend running `/wiki promote <tag>` to scaffold a domain hub. Threshold rationale: clusters below ~10 leaves are noisy; LYT MOC heuristics put the mental-squeeze trigger around this size.
-12. **Hub stale-count drift**. For every `wiki/domains/<slug>/_index.md`, compare the hub's frontmatter `page_count:` to the actual inbound count returned by `obsidian backlinks path=wiki/domains/<slug>/_index.md format=json`. Flag drift **> 20 %** (in either direction). Suggest resync — either update `page_count:` to the live count or re-curate the `related:` list to match reality.
-13. **Hub demotion candidates**. For every `wiki/domains/<slug>/_index.md`, count the leaves linked from the hub's `related:` field. If **< 5**, surface the hub as a **demotion candidate** — its cluster is below the hub-worthwhile threshold and the hub may be churn rather than signal. Recommend either growing the cluster or merging the hub into a sibling.
-14. **Notes inbox**. Scoped to `<vault_root>/notes/` only. Two checks:
-    - **Frontmatter gaps** — flag any `notes/*.md` (excluding `notes/index.md`) missing one of: `type`, `title`, `created`, `updated`, `source_project`, `status`. The `topic` and `tags` fields are optional and never flagged.
-    - **Index drift** — flag any file in `notes/` that is missing from `notes/index.md`, and any row in `notes/index.md` whose title text doesn't match any existing note's frontmatter `title:` field. Match against frontmatter `title:`, not filenames — filenames are slugs that may diverge from display titles after CAPTURE rewrites (AC4).
-    - **Explicitly skip** orphan checks, dead-link checks, stale-claim checks, and contradictions for `notes/`. These are wiki-canonical concerns and inappropriate for a transient inbox.
-15. **Misplaced index entries**. For every wikilink in `wiki/index.md`, verify the entry sits under the section matching its target's `type:` frontmatter. Read each linked target via `obsidian read path=<target>` to extract its `type:`, then determine which `## <Section>` heading the entry currently sits under (the nearest preceding H2 in `wiki/index.md`).
+  **Anti-pattern note:** URL-as-wikilink occurrences (e.g. `[[https://...]]`) are in the `anti_patterns` array of the JSON. Report these in a dedicated **Anti-patterns** section; do **not** count them toward the dead-link total.
 
-    Map `type:` → expected section using this fixed table:
+- **Check #6: Frontmatter gaps**. Pages missing required fields (`type`, `status`, `created`, `updated`, `tags`, `confidence`). Additionally, flag missing `evidence:` when `confidence:` is `INFERRED` or `AMBIGUOUS` (per `_shared/frontmatter.md` rule 7 — `evidence:` is required for those confidence levels).
+- **Check #7: Empty sections**. Headings with no content underneath.
+- **Check #8: Stale index entries**. Items in `wiki/index.md` pointing to renamed or deleted pages.
+- **Check #9: hot.md size budget**. Count words in `wiki/hot.md`.
+  - **WARN** if word count > 500 (spec limit per `_shared/hot-cache-protocol.md`).
+  - **FAIL** if word count > 750 (50 % buffer exceeded).
+  - Remediation: move entries older than 2 weeks to `wiki/log.md`; trim `## Last Updated` to the 3–5 most recent items.
+- **Check #10: Backlink density**. Source: `backlinks` map in `lint-data-YYYY-MM-DD.json` (pre-computed by `lint-scan.sh`; do **not** call `obsidian backlinks` per page). For every in-scope page (`.md` and `.canvas`, per the scope definition above), use the precomputed inbound count and compare against the outbound count from the page's frontmatter `related:` length plus inline wikilinks. Flag pages where `inbound ≥ 3` **and** `outbound ≤ 1` — heavily cited but weakly linking. These pages are retrieval-late under the forward-only `related:` model, so surfacing them prompts targeted cross-linking.
+- **Check #11: Hub promotion candidates**. Group all leaves under `wiki/concepts/`, `wiki/entities/`, `wiki/solutions/`, `wiki/sources/` by their primary tag (the first non-type tag in `tags:`). For each tag-cluster of **≥ 10 leaves**, check whether `wiki/domains/<cluster-tag>/_index.md` exists. If it does not, surface the cluster as a **promotion candidate** — recommend running `/wiki promote <tag>` to scaffold a domain hub. Threshold rationale: clusters below ~10 leaves are noisy; LYT MOC heuristics put the mental-squeeze trigger around this size.
+- **Check #12: Hub stale-count drift**. For every `wiki/domains/<slug>/_index.md`, compare the hub's frontmatter `page_count:` to the actual inbound count returned by `obsidian backlinks path=wiki/domains/<slug>/_index.md format=json`. Flag drift **> 20 %** (in either direction). Suggest resync — either update `page_count:` to the live count or re-curate the `related:` list to match reality.
+- **Check #13: Hub demotion candidates**. For every `wiki/domains/<slug>/_index.md`, count the leaves linked from the hub's `related:` field. If **< 5**, surface the hub as a **demotion candidate** — its cluster is below the hub-worthwhile threshold and the hub may be churn rather than signal. Recommend either growing the cluster or merging the hub into a sibling.
+- **Check #14: Notes inbox**. Scoped to `<vault_root>/notes/` only. Two checks:
+  - **Frontmatter gaps** — flag any `notes/*.md` (excluding `notes/index.md`) missing one of: `type`, `title`, `created`, `updated`, `source_project`, `status`. The `topic` and `tags` fields are optional and never flagged.
+  - **Index drift** — flag any file in `notes/` that is missing from `notes/index.md`, and any row in `notes/index.md` whose title text doesn't match any existing note's frontmatter `title:` field. Match against frontmatter `title:`, not filenames — filenames are slugs that may diverge from display titles after CAPTURE rewrites (AC4).
+  - **Explicitly skip** orphan checks, dead-link checks, stale-claim checks, and contradictions for `notes/`. These are wiki-canonical concerns and inappropriate for a transient inbox.
+- **Check #15: Misplaced index entries**. For every wikilink in `wiki/index.md`, verify the entry sits under the section matching its target's `type:` frontmatter. Read each linked target via `obsidian read path=<target>` to extract its `type:`, then determine which `## <Section>` heading the entry currently sits under (the nearest preceding H2 in `wiki/index.md`).
 
-    | `type:` | Expected section |
-    |---|---|
-    | concept | `## Concepts` |
-    | source | `## Sources` |
-    | synthesis | `## Plans & Decisions` (or `## Synthesis` if separate) |
-    | decision | `## Plans & Decisions` |
-    | meta | (no section — sits in the Navigation row, not in the body) |
-    | domain | `## Domains` |
+  Map `type:` → expected section using this fixed table:
 
-    Types not listed above are skipped (no flag) — extend the table when a new type acquires a canonical section.
+  | `type:`   | Expected section                                           |
+  | --------- | ---------------------------------------------------------- |
+  | concept   | `## Concepts`                                              |
+  | source    | `## Sources`                                               |
+  | synthesis | `## Plans & Decisions` (or `## Synthesis` if separate)     |
+  | decision  | `## Plans & Decisions`                                     |
+  | meta      | (no section — sits in the Navigation row, not in the body) |
+  | domain    | `## Domains`                                               |
 
-    - **Strays** — entries with no preceding H2 (above the first heading) flag as `entry above all sections, expected under <Section>`.
-    - **Misplacements** — entries under a non-matching section flag as `entry under <Current> but type=<X> expects <Expected>`.
+  Types not listed above are skipped (no flag) — extend the table when a new type acquires a canonical section.
+  - **Strays** — entries with no preceding H2 (above the first heading) flag as `entry above all sections, expected under <Section>`.
+  - **Misplacements** — entries under a non-matching section flag as `entry under <Current> but type=<X> expects <Expected>`.
 
-    Role: **safety net**, not the primary placement mechanism. `/save` writes new entries directly under the correct section (see #84), so a healthy vault reports zero findings here. Findings indicate drift — manual edits, pre-fix history, or an agent that picked the wrong section despite the corrected `/save` snippet. Auto-fix policy is **ask-first** (see Before Auto-Fixing).
+  Role: **safety net**, not the primary placement mechanism. `/save` writes new entries directly under the correct section (see #84), so a healthy vault reports zero findings here. Findings indicate drift — manual edits, pre-fix history, or an agent that picked the wrong section despite the corrected `/save` snippet. Auto-fix policy is **ask-first** (see Before Auto-Fixing).
 
-16. **Trail integrity**. Scoped to `wiki/trails/*.md`. Trails are run-records emitted by `/autoresearch` and frozen at write time, so integrity checks run against a fixed shape. For each trail page:
-    - **Required trail-specific frontmatter** — flag missing `topic:`, `research_run:`, or `synthesis:`. The universal fields (`type`, `title`, `created`, `updated`, `tags`, `status`, `confidence`, plus `evidence` when `confidence` is `INFERRED`/`AMBIGUOUS`) are check #6's responsibility — do not duplicate.
-    - **Synthesis link resolves** — the `synthesis:` value is a wikilink-by-title (e.g. `[[Research: Topic]]`), not a vault-relative path, so `read path=` is not the right resolver. Instead, run `obsidian unresolved format=json` once per lint pass and check whether the stripped link text appears in the returned `[{"link": "..."}]` array. Membership in that array means the link is dead — flag `synthesis: [[Research: X]] does not resolve`.
-    - **Body is an ordered list** — the trail body (everything below the first H1, excluding a single optional intro paragraph) must be exactly one ordered Markdown list (`1. …`, `2. …`, …). Flag `body is not an ordered list` for trails whose body has no ordered list, multiple top-level lists, prose paragraphs interleaved with list items, or nested lists.
-    - **Every list item contains a wikilink and a plain-text annotation** — for each ordered-list item, flag the item if it has zero `[[wikilink]]`s, more than one `[[wikilink]]`, no annotation text after stripping the wikilink (the residue must contain at least one non-whitespace, non-punctuation character), or if the annotation text contains a URL (`https?://` or a Markdown link `[text](url)`) or an additional `[[wikilink]]` — annotation text must be plain text (inline formatting like bold/italic is permitted; links are not).
-    - **No minimum link count.** A one-step trail is valid output and must not be flagged.
+- **Check #16: Trail integrity**. Scoped to `wiki/trails/*.md`. Trails are run-records emitted by `/autoresearch` and frozen at write time, so integrity checks run against a fixed shape. For each trail page:
+  - **Required trail-specific frontmatter** — flag missing `topic:`, `research_run:`, or `synthesis:`. The universal fields (`type`, `title`, `created`, `updated`, `tags`, `status`, `confidence`, plus `evidence` when `confidence` is `INFERRED`/`AMBIGUOUS`) are check #6's responsibility — do not duplicate.
+  - **Synthesis link resolves** — the `synthesis:` value is a wikilink-by-title (e.g. `[[Research: Topic]]`), not a vault-relative path, so `read path=` is not the right resolver. Instead, run `obsidian unresolved format=json` once per lint pass and check whether the stripped link text appears in the returned `[{"link": "..."}]` array. Membership in that array means the link is dead — flag `synthesis: [[Research: X]] does not resolve`.
+  - **Body is an ordered list** — the trail body (everything below the first H1, excluding a single optional intro paragraph) must be exactly one ordered Markdown list (`1. …`, `2. …`, …). Flag `body is not an ordered list` for trails whose body has no ordered list, multiple top-level lists, prose paragraphs interleaved with list items, or nested lists.
+  - **Every list item contains a wikilink and a plain-text annotation** — for each ordered-list item, flag the item if it has zero `[[wikilink]]`s, more than one `[[wikilink]]`, no annotation text after stripping the wikilink (the residue must contain at least one non-whitespace, non-punctuation character), or if the annotation text contains a URL (`https?://` or a Markdown link `[text](url)`) or an additional `[[wikilink]]` — annotation text must be plain text (inline formatting like bold/italic is permitted; links are not).
+  - **No minimum link count.** A one-step trail is valid output and must not be flagged.
 
-    Auto-fix policy: **never auto-fix**. Trails are run-snapshots; rewriting them post-emission destroys the run-record property. Findings here are advisory — the user repairs the trail manually or accepts the drift.
+  Auto-fix policy: **never auto-fix**. Trails are run-snapshots; rewriting them post-emission destroys the run-record property. Findings here are advisory — the user repairs the trail manually or accepts the drift.
 
 ---
 
@@ -118,33 +121,42 @@ status: developing
 # Lint Report: YYYY-MM-DD
 
 ## Summary
+
 - Pages scanned: N
 - Issues found: N
 - Auto-fixed: N
 - Needs review: N
 
 ## Orphan Pages
+
 - [[Page Name]]: no inbound links. Suggest: link from [[Related Page]] or delete.
 
 ## Dead Links
+
 - [[Missing Page]]: referenced in [[Source Page]] but does not exist. Suggest: create stub or remove link.
 
 ## Frontmatter Gaps
+
 - [[Page Name]]: missing fields: status, tags
 
 ## Backlink Density
+
 - [[Page Name]]: N inbound, M outbound. Heavily cited, weakly linking. Suggest: add `related:` entries on this page to its top citers, or thread it into a domain hub.
 
 ## Hub Promotion Candidates
+
 - `<tag>`: N leaves share this tag, no `wiki/domains/<tag>/_index.md`. Suggest: `/wiki promote <tag>` to scaffold a hub.
 
 ## Hub Stale-Count Drift
+
 - [[domains/<slug>/_index]]: `page_count: N` in frontmatter, M inbound backlinks (drift: ±X%). Suggest: update `page_count:` or re-curate `related:`.
 
 ## Hub Demotion Candidates
+
 - [[domains/<slug>/_index]]: only N leaves linked. Below threshold (5). Suggest: grow the cluster or merge into a sibling hub.
 
 ## Hot Cache Size
+
 - hot.md: N words (spec: 500, delta: +N). Status: OK | WARN | FAIL
   - Suggest: move entries older than 2026-XX-XX to [[log]], trim ## Last Updated to top 3–5 items.
 
@@ -153,13 +165,16 @@ status: developing
 Scope: `notes/` only. Frontmatter gaps and index drift; no orphan/dead-link/stale checks.
 
 ### Frontmatter gaps
+
 - `notes/<filename>.md`: missing fields: <field>, <field>
 
 ### Index drift
+
 - File missing from index: `notes/<filename>.md` (no row in `notes/index.md`)
 - Index row missing file: `notes/index.md` references "<title>" but no file resolves to it
 
 ## Misplaced Index Entries
+
 - `[[<slug>]]`: under `<Current>`, expected `<Expected>` (type=<x>). Suggest: move under `<Expected>`.
 - `[[<slug>]]`: above all sections (stray). Suggest: move under `<Expected>`.
 
@@ -186,12 +201,12 @@ Not counted toward dead-link total. Each entry is `[[https://...]]` used as a wi
 
 Enforce these during lint:
 
-| Element | Convention | Example |
-|---------|-----------|---------|
-| Filenames | Title Case with spaces | `Machine Learning.md` |
-| Folders | lowercase with dashes | `wiki/data-models/` |
-| Tags | lowercase, hierarchical | `#domain/architecture` |
-| Wikilinks | match filename exactly | `[[Machine Learning]]` |
+| Element   | Convention              | Example                |
+| --------- | ----------------------- | ---------------------- |
+| Filenames | Title Case with spaces  | `Machine Learning.md`  |
+| Folders   | lowercase with dashes   | `wiki/data-models/`    |
+| Tags      | lowercase, hierarchical | `#domain/architecture` |
+| Wikilinks | match filename exactly  | `[[Machine Learning]]` |
 
 Filenames must be unique across the vault. Wikilinks work without paths only if filenames are unique.
 
@@ -275,8 +290,10 @@ Create or update `wiki/meta/overview.canvas` for a visual domain map. Use `wiki/
       "id": "1",
       "type": "file",
       "file": "wiki/index.md",
-      "x": 0, "y": 0,
-      "width": 300, "height": 140,
+      "x": 0,
+      "y": 0,
+      "width": 300,
+      "height": 140,
       "color": "1"
     }
   ],
@@ -293,17 +310,20 @@ Add one node per domain hub (`wiki/domains/<slug>/_index.md`). Connect hubs that
 Always show the lint report first. Ask: "Should I fix these automatically, or do you want to review each one?"
 
 Safe to auto-fix:
+
 - Adding missing frontmatter fields with placeholder values
 - Creating stub pages for missing entities
 - Adding wikilinks for unlinked mentions
 
 Needs review before fixing:
+
 - Deleting orphan pages (they might be intentionally isolated)
 - Resolving contradictions (requires human judgment)
 - Merging duplicate pages
 - Moving misplaced index entries (check #15). Rationale: low expected volume in a healthy vault makes batch auto-move offer little value over per-entry confirmation, and a misclassification (e.g., a concept intentionally filed under a different section) is harder to undo than to confirm.
 
 Never auto-fix:
+
 - Trail integrity findings (check #16). Trails are frozen-at-write-time run-snapshots; rewriting them post-emission destroys the run-record property. Surface the finding and let the user repair manually or accept the drift.
 
 ---

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: lint
-description: >
-  Health check the Obsidian wiki vault. Finds orphan pages, dead wikilinks, stale claims,
-  missing cross-references, frontmatter gaps, and empty sections. Creates or updates
-  Bases dashboards. Generates canvas maps. Triggers on: "lint", "health check",
-  "clean up wiki", "check the wiki", "wiki maintenance", "find orphans", "wiki audit".
+description: Health check the wiki vault. Finds orphans, dead wikilinks, stale claims, and frontmatter gaps. Generates canvas maps and Bases dashboards.
 allowed-tools: Bash Read Glob Grep
 ---
 

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -35,7 +35,7 @@ The deterministic scan script (`scripts/lint-scan.sh`) uses this scope. Two runs
 
 The lint agent (`agents/lint.md`) runs `scripts/lint-scan.sh` first to produce `wiki/meta/lint-data-YYYY-MM-DD.json`. Checks #1, #2, and #10 read directly from that JSON; the remaining checks use the native `obsidian` CLI verbs or page reads as noted below.
 
-When invoking CLI verbs directly (checks #3–#9, #11–#16):
+When invoking CLI verbs directly (checks #6–#9, #11–#16):
 - Inbound links per page: `obsidian backlinks path=<page> format=json` (returns `[{"file": "<path>"}]`; count entries for the inbound-link count) — only needed if the JSON backlinks map is not available.
 - Unresolved links: `obsidian unresolved format=json` (returns `[{"link": "..."}]`)
 
@@ -45,9 +45,6 @@ Work through these in order:
 2. **Dead links**. Source: `dead_links` array in `lint-data-YYYY-MM-DD.json`. Each entry is `{source_page, link_text}` — a wikilink in `source_page` that does not resolve to any existing page. Canvas dead links are merged into the same array; no separate handling. Findings inside `wiki/trails/*.md` are surfaced for visibility but **never auto-fixed** — trails are run-snapshots frozen at write time; the user repairs manually or accepts the drift (same policy as check #16).
 
     **Anti-pattern note:** URL-as-wikilink occurrences (e.g. `[[https://...]]`) are in the `anti_patterns` array of the JSON. Report these in a dedicated **Anti-patterns** section; do **not** count them toward the dead-link total.
-3. **Stale claims**. Assertions on older pages that newer sources have contradicted or updated.
-4. **Missing pages**. Concepts or entities mentioned in multiple pages but lacking their own page.
-5. **Missing cross-references**. Entities mentioned in a page but not linked.
 6. **Frontmatter gaps**. Pages missing required fields (`type`, `status`, `created`, `updated`, `tags`, `confidence`). Additionally, flag missing `evidence:` when `confidence:` is `INFERRED` or `AMBIGUOUS` (per `_shared/frontmatter.md` rule 7 — `evidence:` is required for those confidence levels).
 7. **Empty sections**. Headings with no content underneath.
 8. **Stale index entries**. Items in `wiki/index.md` pointing to renamed or deleted pages.
@@ -94,6 +91,16 @@ Work through these in order:
 
 ---
 
+## Manual Review
+
+The following checks require entity-extraction or semantic contradiction detection that cannot be automated without NLP infrastructure. They are not run by the lint agent. Perform them as a periodic human review (suggested: monthly, or after a burst of ingests from a new domain).
+
+- **Stale claims.** Look for assertions on older pages that newer sources may have contradicted or updated. Focus on pages with `confidence: INFERRED` or `AMBIGUOUS` and compare their claims against recently ingested sources in the same domain.
+- **Missing pages.** Look for concepts or entities mentioned in three or more pages that lack their own wiki page. Use the hot cache and index as a starting point; search for recurring noun phrases that have no `[[wikilink]]` target.
+- **Missing cross-references.** Look for entity names mentioned in page prose without a `[[wikilink]]`. Focus on high-traffic entities visible in the backlink density report (check #10).
+
+---
+
 ## Lint Report Format
 
 Create at `wiki/meta/lint-report-YYYY-MM-DD.md`:
@@ -122,17 +129,8 @@ status: developing
 ## Dead Links
 - [[Missing Page]]: referenced in [[Source Page]] but does not exist. Suggest: create stub or remove link.
 
-## Missing Pages
-- "concept name": mentioned in [[Page A]], [[Page B]], [[Page C]]. Suggest: create a concept page.
-
 ## Frontmatter Gaps
 - [[Page Name]]: missing fields: status, tags
-
-## Stale Claims
-- [[Page Name]]: claim "X" may conflict with newer source [[Newer Source]].
-
-## Cross-Reference Gaps
-- [[Entity Name]] mentioned in [[Page A]] without a wikilink.
 
 ## Backlink Density
 - [[Page Name]]: N inbound, M outbound. Heavily cited, weakly linking. Suggest: add `related:` entries on this page to its top citers, or thread it into a domain hub.

--- a/skills/notes/SKILL.md
+++ b/skills/notes/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: notes
-description: >
-  Capture quick inbox notes into the vault without breaking flow. Verbatim
-  capture, silent auto-match append on overlap, silent file creation on no
-  match. Per-project filtering via source_project. Listing and processing
-  flows for triaging the inbox later. Triggers on: "/note", "/dump",
-  "note this", "remember this for later", "add to inbox", "todo:",
-  "show my inbox", "/note list", "what's in notes",
-  "/note process", "process my notes", "process the inbox",
-  "triage the inbox".
+description: Capture quick inbox notes without breaking flow. Verbatim capture with auto-match. Per-project filtering. Lists and triages the inbox.
 allowed-tools: Bash Read Glob Grep
 ---
 

--- a/skills/obsidian-bases/SKILL.md
+++ b/skills/obsidian-bases/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obsidian-bases
-description: "Create and edit Obsidian Bases (.base files): Obsidian's native database layer for dynamic tables, card views, list views, filters, formulas, and summaries over vault notes. Triggers on: create a base, add a base file, obsidian bases, base view, filter notes, formula, database view, dynamic table, task tracker base, reading list base."
+description: Create and edit Obsidian Bases (.base files) — dynamic tables, cards, lists, filters, and formulas over vault notes.
 allowed-tools: Bash Read Glob
 ---
 

--- a/skills/obsidian-markdown/SKILL.md
+++ b/skills/obsidian-markdown/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obsidian-markdown
-description: "Write correct Obsidian Flavored Markdown: wikilinks, embeds, callouts, properties, tags, highlights, math, and canvas syntax. Reference this when creating or editing any wiki page. Triggers on: write obsidian note, obsidian syntax, wikilink, callout, embed, obsidian markdown, wikilink format, callout syntax, embed syntax, obsidian formatting, how to write obsidian markdown."
+description: "Write correct Obsidian Flavored Markdown: wikilinks, embeds, callouts, properties, tags, and math. Reference when creating any wiki page."
 allowed-tools: Read Write Edit
 ---
 

--- a/skills/obsidian-markdown/SKILL.md
+++ b/skills/obsidian-markdown/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obsidian-markdown
-description: "Write correct Obsidian Flavored Markdown: wikilinks, embeds, callouts, properties, tags, and math. Reference when creating any wiki page."
+description: Write correct Obsidian Flavored Markdown: wikilinks, embeds, callouts, properties, tags, and math. Reference when creating any wiki page.
 allowed-tools: Read Write Edit
 ---
 

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: query
-description: "Answer questions using the Obsidian wiki vault. Reads hot cache first, then index, then relevant pages. Synthesizes answers with citations. Files good answers back as wiki pages. Supports quick, standard, and deep modes. Triggers on: what do you know about, query:, what is, explain, summarize, find in wiki, search the wiki, based on the wiki, wiki query quick, wiki query deep."
+description: Answer questions from the wiki vault. Reads hot cache then index then pages, synthesizes with citations. Files good answers back.
 allowed-tools: Bash Read Glob Grep
 ---
 

--- a/skills/save/SKILL.md
+++ b/skills/save/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: save
-description: >
-  Save the current conversation, answer, or insight into the Obsidian wiki vault as a
-  structured note. Analyzes the chat, determines the right note type, creates frontmatter,
-  files it in the correct wiki folder, and updates index, log, and hot cache.
-  Triggers on: "save this", "save that answer", "/save", "file this",
-  "save to wiki", "save this session", "file this conversation", "keep this",
-  "save this analysis", "add this to the wiki".
+description: Save the current conversation or insight as a structured wiki note. Determines note type, files it, and updates index, log, and hot cache.
 allowed-tools: Bash Read Glob Grep
 ---
 

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: wiki
-description: >
-  Claude + Obsidian knowledge companion. Sets up a persistent wiki vault, scaffolds
-  structure from a one-sentence description, and routes to specialized sub-skills.
-  Use for setup, scaffolding, cross-project referencing, and hot cache management.
-  Triggers on: "set up wiki", "scaffold vault", "create knowledge base", "/wiki",
-  "wiki setup", "obsidian vault", "knowledge base", "second brain setup",
-  "running notetaker", "persistent memory", "llm wiki".
+description: Claude + Obsidian knowledge companion. Bootstraps the vault, scaffolds structure, and routes to specialized sub-skills.
 allowed-tools: Bash Read Glob Grep
 ---
 


### PR DESCRIPTION
## Context

Closes #107

This PR bundles two related changes:

### 1. Demote lint checks #3, #4, #5 from automated to manual advisory

Checks #3 (stale claims), #4 (missing pages), and #5 (missing cross-references) have never had a working algorithm in the lint agent — all three historical runs skipped or flagged them as non-automatable. This change removes them from the automated checklist and preserves their intent as human-advisory guidance.

### 2. Trim skill frontmatter descriptions (≤150 chars, drop Triggers-on lists)

All skill `description:` fields were trimmed to ≤150 characters and the `Triggers-on:` metadata sections removed. These fields are used by Claude Code's skill picker and don't benefit from prose length or trigger lists (the real trigger matching is in the manifest).

## Acceptance Criteria

- [x] Checks #3, #4, #5 removed from the numbered list in `skills/lint/SKILL.md` and from the step-by-step instructions in `agents/lint.md`
- [x] Intent preserved under a new `## Manual Review` section in `skills/lint/SKILL.md`, with concrete guidance on what to look for during a periodic human review
- [x] `## Stale Claims`, `## Cross-Reference Gaps`, and `## Missing Pages` removed from the lint report format template in `skills/lint/SKILL.md`
- [x] `agents/lint.md` description frontmatter updated to no longer mention stale claims or missing cross-references
- [x] All skill `description:` fields trimmed to ≤150 characters
- [x] `Triggers-on:` sections removed from all skill files where present

## Testing

No code executes — these are agent instruction files. Verify by reading the changed sections:

1. `skills/lint/SKILL.md` `## Lint Checks`: unordered list with explicit `Check #N:` labels; no mention of stale claims, missing pages, or cross-references.
2. `skills/lint/SKILL.md` `## Manual Review` (new section before `## Lint Report Format`): three advisory bullets for the demoted checks.
3. `skills/lint/SKILL.md` `## Lint Report Format` template: no `## Stale Claims`, `## Missing Pages`, or `## Cross-Reference Gaps` sections.
4. `agents/lint.md` Step 2: jumps from Check #2 to Check #6.
5. All `SKILL.md` `description:` fields: ≤150 chars, no `Triggers-on:` lists.