### PR TITLE
lint: move empty-sections check (#7) to lint-scan.sh

### DIFF
--- a/agents/lint.md
+++ b/agents/lint.md
@@ -24,7 +24,7 @@ Work through checks in `skills/lint/SKILL.md` order using JSON where available, 
 - **#1 (orphans):** use JSON `orphans`.
 - **#2 (dead links):** use JSON `dead_links` (canvas merged).
 - **#6 (frontmatter gaps):** read in-scope pages per `scope.scanned_dirs`.
-- **#7 (empty sections):** For each in-scope page (per `scope.scanned_dirs`), read the file and scan line by line. A heading (`^#{2,} `) is empty when the next non-blank line is another heading (`^#`) or there are no further non-blank lines in the file. Report each as `[[page-slug]]: empty section "## Heading Title"`.
+- **#7 (empty sections):** use JSON `empty_sections`. Each entry is `{source_page, heading}`. Report each as `[[slug]]: empty section "<heading>"`.
 - **#8 (stale index):** `obsidian read path=wiki/index.md` + validate.
 - **#9 (hot.md size):** read + word count.
 - **#10 (backlink density):** use JSON `backlinks`.

--- a/agents/lint.md
+++ b/agents/lint.md
@@ -24,7 +24,7 @@ Work through checks in `skills/lint/SKILL.md` order using JSON where available, 
 - **#1 (orphans):** use JSON `orphans`.
 - **#2 (dead links):** use JSON `dead_links` (canvas merged).
 - **#6 (frontmatter gaps):** read in-scope pages per `scope.scanned_dirs`.
-- **#7 (empty sections):** read pages.
+- **#7 (empty sections):** For each in-scope page (per `scope.scanned_dirs`), read the file and scan line by line. A heading (`^#{2,} `) is empty when the next non-blank line is another heading (`^#`) or there are no further non-blank lines in the file. Report each as `[[page-slug]]: empty section "## Heading Title"`.
 - **#8 (stale index):** `obsidian read path=wiki/index.md` + validate.
 - **#9 (hot.md size):** read + word count.
 - **#10 (backlink density):** use JSON `backlinks`.

--- a/scripts/lint-scan.sh
+++ b/scripts/lint-scan.sh
@@ -195,6 +195,57 @@ for page in "${md_pages[@]}"; do
   done < <(grep -oP '(?<=\[\[)[^\]]+(?=\]\])' <<< "$content" 2>/dev/null | sort -u)
 done
 
+# ─── Empty sections ──────────────────────────────────────────────────────────
+# A heading (## or deeper) is empty when the next non-blank line is another
+# heading or there are no further non-blank lines. Frontmatter and code blocks
+# are excluded so fenced content can't produce false positives.
+
+empty_sections_entries=()
+for page in "${md_pages[@]}"; do
+  content=$("$CLI" read "path=${page}" 2>/dev/null) || continue
+
+  in_frontmatter=false
+  in_code_block=false
+  prev_heading=""
+  saw_content=false
+  first_line=true
+
+  while IFS= read -r line; do
+    if $first_line; then
+      first_line=false
+      if [[ "$line" == "---" ]]; then in_frontmatter=true; continue; fi
+    fi
+    if $in_frontmatter; then
+      [[ "$line" == "---" || "$line" == "..." ]] && in_frontmatter=false
+      continue
+    fi
+    if [[ "$line" =~ ^(\`\`\`|~~~) ]]; then
+      $in_code_block && in_code_block=false || in_code_block=true
+      saw_content=true; continue
+    fi
+    if $in_code_block; then saw_content=true; continue; fi
+
+    if [[ "$line" =~ ^#{2,}[[:space:]] ]]; then
+      if [[ -n "$prev_heading" ]] && ! $saw_content; then
+        empty_sections_entries+=(
+          "$(jq -n --arg p "$page" --arg h "$prev_heading" \
+               '{source_page: $p, heading: $h}')"
+        )
+      fi
+      prev_heading="$line"; saw_content=false
+    elif [[ -n "${line// }" ]]; then
+      saw_content=true
+    fi
+  done <<< "$content"
+
+  if [[ -n "$prev_heading" ]] && ! $saw_content; then
+    empty_sections_entries+=(
+      "$(jq -n --arg p "$page" --arg h "$prev_heading" \
+           '{source_page: $p, heading: $h}')"
+    )
+  fi
+done
+
 # ─── Orphans ─────────────────────────────────────────────────────────────────
 orphans_list=()
 while IFS= read -r p; do
@@ -256,6 +307,13 @@ else
   anti_json='[]'
 fi
 
+if [[ ${#empty_sections_entries[@]} -gt 0 ]]; then
+  empty_sections_json=$(printf '%s\n' "${empty_sections_entries[@]}" \
+    | jq -s 'sort_by(.source_page, .heading)')
+else
+  empty_sections_json='[]'
+fi
+
 backlinks_json=$(
   {
     for key in $(printf '%s\n' "${!backlink_counts[@]}" | sort); do
@@ -278,6 +336,7 @@ output=$(jq -n \
   --argjson orphans            "$orphans_json" \
   --argjson unresolved_targets "$unresolved_json" \
   --argjson anti_patterns      "$anti_json" \
+  --argjson empty_sections     "$empty_sections_json" \
   --argjson backlinks          "$backlinks_json" \
   '{
     scan_date:           $scan_date,
@@ -287,6 +346,7 @@ output=$(jq -n \
     orphans:             $orphans,
     unresolved_targets:  $unresolved_targets,
     anti_patterns:       $anti_patterns,
+    empty_sections:      $empty_sections,
     backlinks:           $backlinks
   }')
 

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -63,9 +63,9 @@ The main thread does **not** run the 16 lint checks itself — the agent owns th
 
 ## Lint Checks
 
-The lint agent (`agents/lint.md`) runs `scripts/lint-scan.sh` first to produce `wiki/meta/lint-data-YYYY-MM-DD.json`. Checks #1, #2, and #10 read directly from that JSON; the remaining checks use the native `obsidian` CLI verbs or page reads as noted below.
+The lint agent (`agents/lint.md`) runs `scripts/lint-scan.sh` first to produce `wiki/meta/lint-data-YYYY-MM-DD.json`. Checks #1, #2, #7, and #10 read directly from that JSON; the remaining checks use the native `obsidian` CLI verbs or page reads as noted below.
 
-When invoking CLI verbs directly (checks #6–#9, #11–#16):
+When invoking CLI verbs directly (checks #6, #8–#9, #11–#16):
 
 - Inbound links per page: `obsidian backlinks path=<page> format=json` (returns `[{"file": "<path>"}]`; count entries for the inbound-link count) — only needed if the JSON backlinks map is not available.
 - Unresolved links: `obsidian unresolved format=json` (returns `[{"link": "..."}]`)
@@ -78,7 +78,7 @@ Work through these in order:
   **Anti-pattern note:** URL-as-wikilink occurrences (e.g. `[[https://...]]`) are in the `anti_patterns` array of the JSON. Report these in a dedicated **Anti-patterns** section; do **not** count them toward the dead-link total.
 
 - **Check #6: Frontmatter gaps**. Pages missing required fields (`type`, `status`, `created`, `updated`, `tags`, `confidence`). Additionally, flag missing `evidence:` when `confidence:` is `INFERRED` or `AMBIGUOUS` (per `_shared/frontmatter.md` rule 7 — `evidence:` is required for those confidence levels).
-- **Check #7: Empty sections**. Headings with no content underneath.
+- **Check #7: Empty sections**. Source: `empty_sections` array in `lint-data-YYYY-MM-DD.json`. Each entry is `{source_page, heading}` — a heading (`##` or deeper) with no non-blank content before the next heading or end-of-file. Frontmatter and fenced code blocks are excluded.
 - **Check #8: Stale index entries**. Items in `wiki/index.md` pointing to renamed or deleted pages.
 - **Check #9: hot.md size budget**. Count words in `wiki/hot.md`.
   - **WARN** if word count > 500 (spec limit per `_shared/hot-cache-protocol.md`).


### PR DESCRIPTION
## Summary

Moves check #7 (empty sections) from agent-driven page reads to a deterministic script pass in `lint-scan.sh`, consistent with checks #1/#2/#10. The script now produces an `empty_sections` array in the lint-data JSON; `agents/lint.md` check #7 collapses to `use JSON empty_sections`; `skills/lint/SKILL.md` is updated to document the new source.

## Changes

- `scripts/lint-scan.sh` — new section detects headings (`##` or deeper) whose next non-blank line is another heading or end-of-file; excludes frontmatter and fenced code blocks; emits `{source_page, heading}` entries sorted for determinism
- `agents/lint.md` — check #7 now reads `JSON empty_sections` instead of doing per-page reads
- `skills/lint/SKILL.md` — check #7 entry documents JSON source; inventory summary updated from "Checks #1, #2, and #10" to "Checks #1, #2, #7, and #10"

## Testing notes

- Simulated algorithm against `tests/fixtures/lint-audit/wiki/concepts/concept-a.md` — correctly surfaces `[[concept-a]]: empty section "## Details"` (`## Details` at line 23, blank at 24, `## Relationships` at 25)
- Frontmatter exclusion: YAML block skipped before heading scan begins
- Code fence exclusion: content between ```` ``` ```` / `~~~` markers marked as `saw_content=true`, not treated as headings

Closes #108