### PR TITLE
feat(frontmatter): add Agent/WebFetch to allowed-tools and argument-hint to commands (PR1)

### DIFF
--- a/commands/autoresearch.md
+++ b/commands/autoresearch.md
@@ -1,5 +1,6 @@
 ---
 description: Autonomous iterative research loop. Searches the web, dispatches agents to fetch and synthesize sources, and files everything into the wiki as structured pages.
+argument-hint: "[topic]"
 ---
 Run the `autoresearch` skill for the given topic or ask "What topic should I research?"
 

--- a/commands/canvas.md
+++ b/commands/canvas.md
@@ -1,6 +1,6 @@
 ---
 description: Open, create, or update a visual canvas — add images, text, PDFs, wiki pages, and banana-generated assets to Obsidian canvas files.
-argument-hint: "[new|add image|add text|zone|list]"
+argument-hint: "[new|add image|add text|add pdf|add note|zone|list|from banana]"
 ---
 Run the `canvas` skill matching user command:
 

--- a/commands/canvas.md
+++ b/commands/canvas.md
@@ -1,5 +1,6 @@
 ---
 description: Open, create, or update a visual canvas — add images, text, PDFs, wiki pages, and banana-generated assets to Obsidian canvas files.
+argument-hint: "[new|add image|add text|zone|list]"
 ---
 Run the `canvas` skill matching user command:
 

--- a/commands/save.md
+++ b/commands/save.md
@@ -1,5 +1,6 @@
 ---
 description: Save the current conversation or a specific insight into the wiki vault as a structured note.
+argument-hint: "[name|session|concept [name]|decision [name]]"
 ---
 Run `save` skill. Usage:
 - `/save` — analyze conversation and save most valuable content

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous research loop. Searches the web, synthesizes findings, and files structured wiki pages.
-allowed-tools: Bash Read Glob Grep WebFetch WebSearch
+allowed-tools: Bash Read Glob Grep WebFetch WebSearch Agent
 ---
 # autoresearch
 

--- a/skills/braindump/SKILL.md
+++ b/skills/braindump/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: braindump
 description: Split long-form text into atomic inbox notes. Accepts inline text or file paths. Triage later via /note process.
-allowed-tools: Bash Read Glob Grep
+allowed-tools: Bash Read Glob Grep Agent
 ---
 # braindump
 

--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: canvas
 description: Visual layer of the wiki. Add images, text cards, PDFs, and wiki pages to canvas files with zones.
-allowed-tools: Bash Read Glob Grep WebFetch
+allowed-tools: Bash Read Glob Grep
 ---
 # canvas
 

--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: canvas
 description: Visual layer of the wiki. Add images, text cards, PDFs, and wiki pages to canvas files with zones.
-allowed-tools: Bash Read Glob Grep
+allowed-tools: Bash Read Glob Grep WebFetch
 ---
 # canvas
 

--- a/skills/daily-close/SKILL.md
+++ b/skills/daily-close/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: daily-close
 description: Synthesize a day's captures into a prose summary. Idempotent; re-run replaces prior summary.
-allowed-tools: Bash Read Glob
+allowed-tools: Bash Read Glob Agent
 ---
 # daily-close
 

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ingest
 description: Ingest sources into wiki. Extracts entities/concepts, creates/updates pages, cross-references. Supports files and URLs.
-allowed-tools: Bash Read Glob Grep WebFetch
+allowed-tools: Bash Read Glob Grep WebFetch Agent
 ---
 # ingest
 

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lint
 description: Wiki health check. Orphans, dead links, gaps. Generates canvas maps and Bases dashboards.
-allowed-tools: Bash Read Glob Grep
+allowed-tools: Bash Read Glob Grep Agent
 ---
 # lint
 

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: query
 description: Answer questions from wiki vault. Reads strategically, synthesizes with citations, files answers back.
-allowed-tools: Bash Read Glob Grep
+allowed-tools: Bash Read Glob Grep Agent
 ---
 # query
 


### PR DESCRIPTION
## Summary

Adds missing `Agent` to `allowed-tools` for the 6 skills that dispatch sub-agents, `WebFetch` to `canvas` (uses curl for image downloads), and `argument-hint` to 3 commands missing it.

## Changes

**Skills — `Agent` added to `allowed-tools`:**
- `autoresearch` — dispatches `source-synth` + `research-round`
- `braindump` — dispatches `capture`
- `daily-close` — dispatches `gather`
- `ingest` — dispatches `ingest` agent
- `lint` — dispatches `lint` agent
- `query` — dispatches `gather`

**Skills — `WebFetch` added:**
- `canvas` — uses `curl` for image URL downloads

**Commands — `argument-hint` added:**
- `autoresearch`: `[topic]`
- `canvas`: `[new|add image|add text|zone|list]`
- `save`: `[name|session|concept [name]|decision [name]]`

## Testing notes

- No logic changes; frontmatter only. Verify the `/` menu shows hints for the 3 updated commands.
- Confirm skills load without errors with the additional `Agent` entry.

## Notes

Part of the frontmatter audit series from #115. Low-risk additions; ships first so sub-agent dispatch is no longer under-declared.

Closes #115 (partially — PR1 of 3)