### PR TITLE
docs(#125): add cross-plugin scope boundary to AUTHORING.md

### DIFF
--- a/AUTHORING.md
+++ b/AUTHORING.md
@@ -61,6 +61,21 @@ Do not promote docs specific to one skill's operation, even if long.
 |`model`|`sonnet`, `opus`, `haiku`, or full model ID.|
 |`user-invocable`|`false` hides skill from `/` menu (orchestrator-only skills).|
 
+## Cross-plugin scope boundary
+
+Skills in this repo operate on **vault contents only**: `wiki/`, `notes/`, `daily/`, `.raw/`, `wiki/meta/`.
+
+**Out-of-scope here** — plugin-authoring audits (SKILL.md quality, AUTHORING.md accuracy, `_shared/` content) belong in the **`claude-workflow:/prune` Authoring Lane** (`misiekhardcore/claude-workflow:skills/prune/SKILL.md`).
+
+**Sibling convention**: `misiekhardcore/claude-workflow:_templates/AUTHORING.md` is the parallel authoring guide for that plugin.
+
+**Worked example — "audit SKILL.md content":**
+
+|Direction|Action|
+|-|-|
+|**Do**|Run `/prune` in `claude-workflow` — the Authoring Lane audits skill files.|
+|**Don't**|Open a `wiki-lint` issue in `claude-obsidian` — vault skills do not inspect skill source files.|
+
 ## Agent Frontmatter
 
 Agents use **`tools`** (allowlist), not `allowed-tools` — using the wrong key is a **silent no-op**.


### PR DESCRIPTION
## Context

Closes #125

Without an explicit boundary note, contributors can mistakenly route plugin-authoring checks (auditing SKILL.md content, AUTHORING.md accuracy) into this repo's vault skills. This PR makes the boundary discoverable by adding a dedicated section to `AUTHORING.md`.

## Acceptance Criteria

1. ✅ A `## Cross-plugin scope boundary` section is added to `AUTHORING.md` directly after `## Skill & Command Frontmatter`.
2. ✅ The section states that skills in this repo operate on **vault contents only** (`wiki/`, `notes/`, `daily/`, `.raw/`, `wiki/meta/`) and directs plugin-authoring audits to `claude-workflow:/prune` Authoring Lane, linking to `misiekhardcore/claude-workflow:skills/prune/SKILL.md`.
3. ✅ The section points at `misiekhardcore/claude-workflow:_templates/AUTHORING.md` as the sibling authoring convention.
4. ✅ A paired Don't/Do table shows that "audit SKILL.md content" belongs in `/prune`, not as a `wiki-lint` issue.

## Testing

Read `AUTHORING.md` lines 64–78. The new section should appear between `## Skill & Command Frontmatter` and `## Agent Frontmatter` and satisfy all four criteria above. No other files are changed.