### PR TITLE
fix: resolve plugin root from script location, not CLAUDE_PLUGIN_ROOT

### DIFF
--- a/hooks/obsidian-cli-rewrite.sh
+++ b/hooks/obsidian-cli-rewrite.sh
@@ -66,9 +66,14 @@ fi
 # Rewrite ONLY the leading `obsidian` token on the first line. Preserves
 # multi-line commands (backslash continuations, here-docs, embedded newlines)
 # verbatim after the first token. Mid-string occurrences of `obsidian` (e.g.
-# inside content=, comments) are not touched. Leave ${CLAUDE_PLUGIN_ROOT}
-# unexpanded so the rewrite is portable — Bash expands it at execution time.
-REWRITTEN=$(printf '%s' "$CMD" | sed -E '1 s~^([[:space:]]*)obsidian([[:space:]]|$)~\1"${CLAUDE_PLUGIN_ROOT}/scripts/obsidian-cli.sh"\2~')
+# inside content=, comments) are not touched.
+#
+# Resolve the plugin root from this script's own location and embed the
+# absolute path literally in the rewritten command. $CLAUDE_PLUGIN_ROOT is
+# not available in the Bash tool's subprocess environment where the rewritten
+# command executes, so it cannot be left for "Bash to expand at runtime".
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REWRITTEN=$(printf '%s' "$CMD" | sed -E "1 s~^([[:space:]]*)obsidian([[:space:]]|\$)~\1\"${PLUGIN_ROOT}/scripts/obsidian-cli.sh\"\2~")
 
 # No-op if the leading token wasn't `obsidian` (e.g. `which obsidian`,
 # `cat $obsidian_path`, `pgrep -f obsidian`).

--- a/tests/cli-smoke.sh
+++ b/tests/cli-smoke.sh
@@ -263,7 +263,7 @@ multiline_cmd=$'obsidian create \\\n  path=wiki/foo.md \\\n  content="alpha\\nbe
 out=$(run_hook "$multiline_cmd")
 rewritten=$(echo "$out" | jq -r '.hookSpecificOutput.updatedInput.command // empty')
 if [ -n "$rewritten" ] \
-   && echo "$rewritten" | head -n1 | grep -qF '"${CLAUDE_PLUGIN_ROOT}/scripts/obsidian-cli.sh" create' \
+   && echo "$rewritten" | head -n1 | grep -qF 'scripts/obsidian-cli.sh" create' \
    && echo "$rewritten" | grep -qF 'path=wiki/foo.md' \
    && echo "$rewritten" | grep -qF 'content="alpha'; then
   pass "multi-line rewrite preserves continuation lines"


### PR DESCRIPTION
## Problem

Every `obsidian` CLI call from the Bash tool fails with:

```
(eval):1: no such file or directory: /scripts/obsidian-cli.sh
```

## Root cause

The rewrite hook replaces the leading `obsidian` token with `"${CLAUDE_PLUGIN_ROOT}/scripts/obsidian-cli.sh"`, leaving `${CLAUDE_PLUGIN_ROOT}` unexpanded with the comment _"Bash expands it at execution time."_

`$CLAUDE_PLUGIN_ROOT` is set inside Claude Code's own process — but the Bash tool executes commands in a subprocess that does **not** inherit that variable. The result is an empty string prefix, producing the literal path `/scripts/obsidian-cli.sh`.

## Fix

Resolve the plugin root from `${BASH_SOURCE[0]}` at hook-run time (when the variable is accessible via the script's own path) and embed the absolute path literally in the rewritten command. No environment variable dependency.

```bash
PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
REWRITTEN=$(printf '%s' "$CMD" | sed -E "1 s~^([[:space:]]*)obsidian([[:space:]]|\$)~\1\"${PLUGIN_ROOT}/scripts/obsidian-cli.sh\"\2~")
```

## Test

```bash
# Before: produces /scripts/obsidian-cli.sh read path=wiki/hot.md
# After:  produces /home/user/.claude/plugins/cache/claude-obsidian/.../scripts/obsidian-cli.sh read path=wiki/hot.md
obsidian read path=wiki/hot.md
```