### PR TITLE
fix(lint-scan): fix backlinks unbound variable under set -u

### DIFF
--- a/scripts/lint-scan.sh
+++ b/scripts/lint-scan.sh
@@ -314,13 +314,17 @@ else
   empty_sections_json='[]'
 fi
 
-backlinks_json=$(
-  {
-    for key in $(printf '%s\n' "${!backlink_counts[@]}" | sort); do
-      jq -n --arg k "$key" --argjson v "${backlink_counts[$key]}" '{($k): $v}'
-    done
-  } | jq -s 'add // {}'
-)
+if [[ ${#backlink_counts[@]} -eq 0 ]]; then
+  backlinks_json='{}'
+else
+  backlinks_json=$(
+    {
+      while IFS= read -r key; do
+        jq -n --arg k "$key" --argjson v "${backlink_counts[$key]:-0}" '{($k): $v}'
+      done < <(printf '%s\n' "${!backlink_counts[@]}" | sort)
+    } | jq -s 'add // {}'
+  )
+fi
 
 # vault commit hash (best-effort)
 vault_commit=""


### PR DESCRIPTION
## Summary

Fixes `lint-scan.sh` crashing with `backlink_counts[$key]: unbound variable` when serializing the backlinks map to JSON.

The bug had two root causes in the serialization loop:
1. `for key in $(...)` applies word-splitting, turning page paths with spaces into invalid keys. Accessing a non-existent key in an associative array under `set -u` raises "unbound variable" in older bash versions.
2. When `backlink_counts` is empty (vault with zero wikilinks), iterating `${!backlink_counts[@]}` could produce an empty key via the same path.

## Changes

- Empty `backlink_counts` array: short-circuit to `backlinks_json='{}'`, avoiding array expansion entirely.
- Non-empty array: switch from `for key in $(...)` to `while IFS= read -r key < <(...)` (process substitution) so the loop runs in the current shell and keys with spaces are preserved.
- Add `${backlink_counts[$key]:-0}` default to bypass any remaining `set -u` edge cases on older bash.

## Testing notes

Repro: run `CLAUDE_PLUGIN_ROOT=<path> bash scripts/lint-scan.sh` from a vault where `backlink_counts` is partially populated or entirely empty. Before: exits with `backlink_counts[$key]: unbound variable`. After: exits 0 and writes a valid JSON file with a `backlinks` object.

Closes #131