### PR TITLE
fix(prune-lint-reports): replace jq filter with grep -E for plain-text files output

### DIFF
--- a/scripts/prune-lint-reports.sh
+++ b/scripts/prune-lint-reports.sh
@@ -44,7 +44,7 @@ prune_pattern() {
   # ISO-8601 dates sort lexically; sort -r puts newest first; tail -n +SKIP
   # emits everything past the top KEEP.
   "$CLI" files dir=wiki/meta \
-    | grep -E "$pattern" \
+    | { grep -E "$pattern" || true; } \
     | sort -r \
     | tail -n "+$SKIP" \
     | while IFS= read -r stale; do

--- a/scripts/prune-lint-reports.sh
+++ b/scripts/prune-lint-reports.sh
@@ -43,14 +43,14 @@ prune_pattern() {
   local pattern="$1"
   # ISO-8601 dates sort lexically; sort -r puts newest first; tail -n +SKIP
   # emits everything past the top KEEP.
-  "$CLI" files dir=wiki/meta format=json \
-    | jq -r --arg pat "$pattern" '.[] | select(.path | test($pat)) | .path' \
+  "$CLI" files dir=wiki/meta \
+    | grep -E "$pattern" \
     | sort -r \
     | tail -n "+$SKIP" \
-    | while read -r stale; do
+    | while IFS= read -r stale; do
         "$CLI" delete path="$stale"
       done
 }
 
-prune_pattern '^wiki/meta/lint-report-[0-9]{4}-[0-9]{2}-[0-9]{2}\\.md$'
-prune_pattern '^wiki/meta/lint-data-[0-9]{4}-[0-9]{2}-[0-9]{2}\\.json$'
+prune_pattern '^wiki/meta/lint-report-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'
+prune_pattern '^wiki/meta/lint-data-[0-9]{4}-[0-9]{2}-[0-9]{2}\.json$'


### PR DESCRIPTION
## Summary

Fixes `prune-lint-reports.sh` crashing with `jq: parse error: Invalid numeric literal` on every run.

`obsidian-cli.sh files` always emits plain-text paths (one per line) regardless of `format=json`. The script piped that plain text straight into `jq`, which expected a JSON array and failed immediately, leaving old lint reports to accumulate without bound.

## Changes

- Drop `format=json` (silently ignored by the `files` verb).
- Replace `jq -r ... | test($pat)` with `grep -E "$pattern"` — plain text in, plain text out.
- Fix pattern escaping at call sites: `\\.` (jq regex syntax for a literal dot) → `\.` (grep -E syntax).
- Add `IFS=` to `while read` for correctness with paths that contain unusual whitespace.

## Testing notes

Repro: `CLAUDE_PLUGIN_ROOT=<path> bash scripts/prune-lint-reports.sh` from any vault. Before: exits with jq parse error, no files deleted. After: exits 0, deletes all but the 3 most recent `lint-report-*.md` and `lint-data-*.json` files. Numeric override (`prune-lint-reports.sh 5`) continues to work.

Closes #132