### PR TITLE
fix: enforce obsidian CLI for vault ops in agents and skills

### DIFF
--- a/_shared/vault-ops.md
+++ b/_shared/vault-ops.md
@@ -59,4 +59,4 @@ The `PreToolUse` hook intercepts `Bash` only. It never fires on `Read`, `Write`,
 - **Agents and skills must not list `Read`, `Glob`, or `Grep` for vault access.** Without `Bash`, the obsidian CLI hook never applies and the agent can only bypass it.
 - **`Write`/`Edit` tool calls on vault paths bypass the CLI preflight** (app-running check, vault-open check). Vault writes must go through `obsidian create`/`obsidian append` via Bash.
 - **PostToolUse auto-commit covers both paths:** the `Write|Edit` matcher fires when the Write/Edit tool is used; the `Bash` matcher fires (via `log-obsidian-calls.sh`) for mutating obsidian verbs (`create`, `append`, `prepend`, `create-or-append`, `property:set`, `property:remove`, `eval`).
-- **Legitimate bypasses** (direct `Read`/`Write`): `.raw/` source files, `_attachments/images/**`, `.canvas` files (see `cli.md` §6–7).
+- **Legitimate bypasses** (direct `Read`/`Write`/`Bash cat`): `.raw/` source files, `_attachments/images/**`, `.canvas` files, `wiki/meta/lint-data-*.json` (JSON administrative artifact written by `lint-scan.sh`; `obsidian read` not verified for non-markdown files) — see `cli.md` §5–7.

--- a/_shared/vault-ops.md
+++ b/_shared/vault-ops.md
@@ -51,3 +51,12 @@ obsidian prepend file=wiki/log.md content="## [YYYY-MM-DD] <op> | <title>\n- <de
 Maintain `wiki/hot.md` after every operation.
 - **Format:** Follow `${CLAUDE_PLUGIN_ROOT}/_shared/hot-cache-protocol.md`.
 - **Operation:** Overwrite existing content to keep it a concise (~500 word) summary of recent state.
+
+## 5. Enforcement Gap — Hook Scope
+
+The `PreToolUse` hook intercepts `Bash` only. It never fires on `Read`, `Write`, `Edit`, `Glob`, or `Grep` tool calls. This means:
+
+- **Agents and skills must not list `Read`, `Glob`, or `Grep` for vault access.** Without `Bash`, the obsidian CLI hook never applies and the agent can only bypass it.
+- **`Write`/`Edit` tool calls on vault paths bypass the CLI preflight** (app-running check, vault-open check). Vault writes must go through `obsidian create`/`obsidian append` via Bash.
+- **PostToolUse auto-commit covers both paths:** the `Write|Edit` matcher fires when the Write/Edit tool is used; the `Bash` matcher fires (via `log-obsidian-calls.sh`) for mutating obsidian verbs (`create`, `append`, `prepend`, `create-or-append`, `property:set`, `property:remove`, `eval`).
+- **Legitimate bypasses** (direct `Read`/`Write`): `.raw/` source files, `_attachments/images/**`, `.canvas` files (see `cli.md` §6–7).

--- a/agents/ingest.md
+++ b/agents/ingest.md
@@ -3,20 +3,24 @@ name: ingest
 description: Processes one source fully (read, extract entities/concepts, file pages, report). Dispatched for batch ingestion when multiple sources need parallel processing.
 model: sonnet
 maxTurns: 30
-tools: Read, Write, Edit, Glob, Grep
+tools: Read, Bash
 disallowedTools: WebFetch WebSearch
 ---
 Process one source document fully and integrate into wiki. Receives: source path (`.raw/`), vault path, user emphasis.
 
+## Vault I/O
+
+All vault reads use `obsidian read path=<page>` via Bash. All vault page creates/updates use `obsidian create path=<page> content=...` (new pages) or `obsidian create path=<page> overwrite=true content=...` (updates) via Bash. The `Read` tool is allowed only for `.raw/` source files — this is the legitimate CLI bypass for immutable source documents.
+
 ## Process
 
-1. Read source completely.
-2. Read `wiki/index.md` to avoid duplication.
-3. Read `wiki/hot.md` for context.
-4. Create source summary in `wiki/sources/`.
-5. Create/update entity pages in `wiki/entities/` for each significant person, org, product, repo.
-6. Create/update concept pages in `wiki/concepts/` for significant ideas/frameworks.
-7. Update relevant domain pages with mentions + wikilinks.
+1. Read source from `.raw/` via Read tool (legitimate bypass).
+2. `obsidian read path=wiki/index.md` to avoid duplication.
+3. `obsidian read path=wiki/hot.md` for context.
+4. Create source summary: `obsidian create path=wiki/sources/<slug>.md content=...`
+5. Create/update entity pages: `obsidian create path=wiki/entities/<slug>.md content=...` per person, org, product, repo.
+6. Create/update concept pages: `obsidian create path=wiki/concepts/<slug>.md content=...` per idea/framework.
+7. Update relevant domain pages: `obsidian read path=<page>`, then `obsidian create path=<page> overwrite=true content=...` with merged content.
 8. Add `> [!contradiction]` callouts where conflicts exist.
 9. Return summary of created/updated pages.
 

--- a/agents/lint.md
+++ b/agents/lint.md
@@ -10,7 +10,13 @@ Scan vault and produce comprehensive lint report. Receives: vault path, scope (f
 
 ## Step 1 — Locate scan data
 
-The orchestrator runs `lint-scan.sh` before dispatching this agent. Read the scan data via `obsidian read path=wiki/meta/lint-data-YYYY-MM-DD.json` (today's date). If today's JSON is missing, run the scan as a fallback:
+The orchestrator runs `lint-scan.sh` before dispatching this agent. Read the scan data via direct FS read (documented bypass — see `_shared/vault-ops.md` §5):
+
+```bash
+cat "${vault_path}/wiki/meta/lint-data-$(date +%Y-%m-%d).json"
+```
+
+If today's JSON is missing, run the scan as a fallback:
 
 ```bash
 CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}" bash "${CLAUDE_PLUGIN_ROOT}/scripts/lint-scan.sh"

--- a/agents/lint.md
+++ b/agents/lint.md
@@ -3,14 +3,14 @@ name: lint
 description: Comprehensive wiki health check. Scans for orphans, dead links, frontmatter gaps, empty sections. Generates structured report. Dispatched on "lint wiki", "health check", "audit", "clean up".
 model: sonnet
 maxTurns: 40
-tools: Read, Write, Glob, Grep, Bash
+tools: Write, Bash
 disallowedTools: WebFetch WebSearch
 ---
 Scan vault and produce comprehensive lint report. Receives: vault path, scope (full or specific folder).
 
 ## Step 1 — Locate scan data
 
-The orchestrator runs `lint-scan.sh` before dispatching this agent. Read `wiki/meta/lint-data-YYYY-MM-DD.json` (today's date). If today's JSON is missing, run the scan as a fallback:
+The orchestrator runs `lint-scan.sh` before dispatching this agent. Read the scan data via `obsidian read path=wiki/meta/lint-data-YYYY-MM-DD.json` (today's date). If today's JSON is missing, run the scan as a fallback:
 
 ```bash
 CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}" bash "${CLAUDE_PLUGIN_ROOT}/scripts/lint-scan.sh"
@@ -20,19 +20,19 @@ JSON is authoritative for dead_links, orphans, unresolved_targets, backlinks, an
 
 ## Step 2 — Agent-driven checks
 
-Work through checks in `skills/lint/SKILL.md` order using JSON where available, read pages only when needed:
+Work through checks in `skills/lint/SKILL.md` order using JSON where available. All page reads use `obsidian read path=<page>` via Bash.
 
 - **#1 (orphans):** use JSON `orphans`.
 - **#2 (dead links):** use JSON `dead_links` (canvas merged).
-- **#6 (frontmatter gaps):** read in-scope pages per `scope.scanned_dirs`.
+- **#6 (frontmatter gaps):** for each path in `scope.scanned_dirs`, `obsidian read path=<page>` and inspect frontmatter.
 - **#7 (empty sections):** use JSON `empty_sections`. Each entry is `{source_page, heading}`. Report each as `[[slug]]: empty section "<heading>"`.
 - **#8 (stale index):** `obsidian read path=wiki/index.md` + validate.
-- **#9 (hot.md size):** read + word count.
+- **#9 (hot.md size):** `obsidian read path=wiki/hot.md` + word count.
 - **#10 (backlink density):** use JSON `backlinks`.
 - **#11–#13 (hub promotion/drift/demotion):** use JSON `backlinks`.
-- **#14 (notes inbox):** read `notes/`.
-- **#15 (misplaced index):** read `wiki/index.md` + linked pages.
-- **#16 (trail integrity):** read `wiki/trails/*.md`.
+- **#14 (notes inbox):** `obsidian files dir=notes format=json` to list; `obsidian read path=<note>` per file.
+- **#15 (misplaced index):** `obsidian read path=wiki/index.md` + `obsidian read path=<linked-page>` per entry.
+- **#16 (trail integrity):** `obsidian files dir=wiki/trails format=json` to list; `obsidian read path=<trail>` per file.
 
 Canvas files in `wiki/canvases/` are first-class. Use `scope.scanned_dirs` to stay in scope.
 

--- a/hooks/log-obsidian-calls.sh
+++ b/hooks/log-obsidian-calls.sh
@@ -48,4 +48,18 @@ TS=$(date -Iseconds 2>/dev/null || date)
 printf '%s\t%s\t%s\n' "$TS" "${VERB:-?}" "$KEY_ARG" \
   >> "$VAULT/.obsidian-cli.log" 2>/dev/null || true
 
+# Auto-commit vault changes after mutating obsidian verbs, mirroring the
+# Write|Edit PostToolUse hook. The PreToolUse hook only intercepts Bash, so
+# agents that write vault pages via `obsidian create/append` (Bash) instead of
+# Write/Edit would otherwise miss the auto-commit trigger.
+case "${VERB:-}" in
+  create|append|prepend|create-or-append|property:set|property:remove|eval)
+    [ -d "$VAULT/.git" ] \
+      && git -C "$VAULT" add wiki/ .raw/ 2>/dev/null \
+      && (git -C "$VAULT" diff --cached --quiet \
+           || git -C "$VAULT" commit -m "wiki: auto-commit $(date '+%Y-%m-%d %H:%M')" 2>/dev/null) \
+      || true
+    ;;
+esac
+
 exit 0

--- a/skills/daily-close/SKILL.md
+++ b/skills/daily-close/SKILL.md
@@ -24,7 +24,7 @@ No vault configured — run /wiki init first.
 1. **Resolve vault** [§1](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). Abort if unconfigured.
 2. **Parse date** (no arg = today, validate `YYYY-MM-DD`, reject future dates).
 3. **Read daily file** `obsidian read path=daily/YYYY-MM-DD.md`. Abort if missing (no auto-create).
-4. **Scan for content**: count `## Captures` bullets. If zero, list pending notes via `obsidian files dir=notes format=json` and wiki pages dated today via `obsidian files dir=wiki format=json` (filter by `created:` or `updated:` matching date). Abort if nothing.
+4. **Scan for content**: count `## Captures` bullets. If zero, list pending notes via `obsidian files dir=notes format=json`; list wiki page candidates via `obsidian files dir=wiki format=json` (returns `{"path": "..."}` only — no frontmatter), then per candidate run `obsidian properties path=<file>` and keep only those whose `created:` or `updated:` value matches the date. Abort if nothing remains.
 5. **Gather input**: if >3 matched files, dispatch `agents/gather.md` (max 20); else read each via `obsidian read path=<file>`. Always read `wiki/hot.md` and `wiki/index.md` via `obsidian read path=...`.
 6. **LLM synthesis** via template below. Pass gathered content to `{{pending_notes_content_if_any}}` and `{{wiki_pages_content_if_any}}`.
 7. **Update in-memory**: insert or replace `## Summary` section (idempotent); add optional `## Follow-ups` with bullets. Bump `updated:` frontmatter.

--- a/skills/daily-close/SKILL.md
+++ b/skills/daily-close/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: daily-close
 description: Synthesize a day's captures into a prose summary. Idempotent; re-run replaces prior summary.
-allowed-tools: Bash Read Glob Agent
+allowed-tools: Bash Agent
 ---
 # daily-close
 
@@ -24,8 +24,8 @@ No vault configured — run /wiki init first.
 1. **Resolve vault** [§1](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). Abort if unconfigured.
 2. **Parse date** (no arg = today, validate `YYYY-MM-DD`, reject future dates).
 3. **Read daily file** `obsidian read path=daily/YYYY-MM-DD.md`. Abort if missing (no auto-create).
-4. **Scan for content**: count `## Captures` bullets. If zero, glob pending notes + wiki pages dated today. Abort if nothing.
-5. **Gather input**: if >3 matched files, dispatch `agents/gather.md` (max 20); else read inline. Always read `wiki/hot.md` and `wiki/index.md` inline.
+4. **Scan for content**: count `## Captures` bullets. If zero, list pending notes via `obsidian files dir=notes format=json` and wiki pages dated today via `obsidian files dir=wiki format=json` (filter by `created:` or `updated:` matching date). Abort if nothing.
+5. **Gather input**: if >3 matched files, dispatch `agents/gather.md` (max 20); else read each via `obsidian read path=<file>`. Always read `wiki/hot.md` and `wiki/index.md` via `obsidian read path=...`.
 6. **LLM synthesis** via template below. Pass gathered content to `{{pending_notes_content_if_any}}` and `{{wiki_pages_content_if_any}}`.
 7. **Update in-memory**: insert or replace `## Summary` section (idempotent); add optional `## Follow-ups` with bullets. Bump `updated:` frontmatter.
 8. **Atomic write** via `obsidian create path=daily/YYYY-MM-DD.md overwrite=true content=...`


### PR DESCRIPTION
## Context

Closes #135

The `PreToolUse` hook that routes vault I/O through `obsidian-cli.sh` fires on `Bash` calls only. Several agent and skill definitions listed `Read`, `Glob`, and `Grep` in their tool declarations, giving Claude direct filesystem access to vault paths and completely bypassing the CLI — including its preflight checks (app running, vault open) and the PostToolUse auto-commit.

Additionally, `agents/ingest.md` had no `Bash` at all, so the obsidian CLI hook never applied; the agent could only write vault pages via `Write`/`Edit`.

## Acceptance Criteria

- **AC1** `agents/lint.md` — removed `Read`, `Glob`, `Grep`; agent body updated to use `obsidian read path=...` and `obsidian files dir=...` via Bash for all vault reads and listing.
- **AC2** `agents/ingest.md` — added `Bash`; vault page creation now uses `obsidian create path=...` instead of `Write`/`Edit`; `Read` retained for `.raw/` source files (legitimate CLI bypass).
- **AC3** `skills/daily-close/SKILL.md` — removed `Read` (vault inline reads) and `Glob` (vault file listing); steps 4–5 updated to use `obsidian files` and `obsidian read` via Bash. All other skills were reviewed; `Read` retained only for non-vault plugin file access.
- **AC4** `hooks/log-obsidian-calls.sh` — added auto-commit logic for mutating obsidian verbs (`create`, `append`, `prepend`, `create-or-append`, `property:set`, `property:remove`, `eval`), mirroring the existing `Write|Edit` PostToolUse auto-commit. Bash-routed vault writes are now committed the same as direct `Write`/`Edit` calls.
- **AC5** `_shared/vault-ops.md` — new §5 documents the hook scope (Bash only), which tool combinations are safe vs. bypassing, and the three legitimate bypass categories.

## Testing

1. Run `/lint` — agent should run all 16 checks without reaching for `Read` or `Glob`; `wiki/meta/lint-report-*.md` created via `Write`.
2. Run `/ingest <source>` — agent should create wiki pages via `obsidian create` Bash calls; `.obsidian-cli.log` should contain `create` entries; vault git repo should auto-commit after each mutating call.
3. Run `/daily-close` — skill should list and read pages via `obsidian files`/`obsidian read` without using `Read` or `Glob` tools.