### PR TITLE
feat: add bootstrap_read_index option to auto-inject wiki/index.md at session start

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -37,6 +37,12 @@
       "type": "string",
       "default": "on-demand",
       "description": "Controls when wiki/hot.md is injected at session start. Values: \"always\" (inject on every session start — ~2–3k tokens/turn baseline); \"on-demand\" (default — skip session-start injection; wiki skills read hot.md when they activate, so wiki sessions are unaffected); \"never\" (same hook behavior as on-demand; additionally signals to skills that they should avoid auto-reading hot.md). Change to \"always\" to restore the pre-v0.4.0 behavior."
+    },
+    "bootstrap_read_index": {
+      "title": "Index auto-read mode",
+      "type": "string",
+      "default": "on-demand",
+      "description": "Controls when wiki/index.md is injected at session start. Values: \"always\" (inject on every session start — ~1–2k tokens/turn baseline, gives Claude a full vault page map); \"on-demand\" (default — skip injection; wiki skills read index.md when they activate)."
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- `bootstrap_read_index` option to auto-inject `wiki/index.md` at session start (mirrors `bootstrap_read_hot`).
 - **`agents/capture.md`** — single CAPTURE-pipeline worker; files one atomic inbox note per invocation. Used by `braindump` for parallel chunk dispatch (#118).
 - **`agents/research-round.md`** — runs one depth-≥2 research branch (search + fetch + source-synth dispatch). Used by `autoresearch` for Round 2 gap-fill and Round 3 synthesis-check phases (#118).
 - **`agents/source-synth.md`** — synthesises one fetched source into wiki pages (entities, concepts, source summary). Used by `autoresearch` and `research-round` (#118).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- `bootstrap_read_index` option to auto-inject `wiki/index.md` at session start (mirrors `bootstrap_read_hot`).
+- `bootstrap_read_index` option to auto-inject `wiki/index.md` at session start and after context compaction when set to `"always"` (mirrors `bootstrap_read_hot`).
 - **`agents/capture.md`** — single CAPTURE-pipeline worker; files one atomic inbox note per invocation. Used by `braindump` for parallel chunk dispatch (#118).
 - **`agents/research-round.md`** — runs one depth-≥2 research branch (search + fetch + source-synth dispatch). Used by `autoresearch` for Round 2 gap-fill and Round 3 synthesis-check phases (#118).
 - **`agents/source-synth.md`** — synthesises one fetched source into wiki pages (entities, concepts, source summary). Used by `autoresearch` and `research-round` (#118).

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The plugin auto-runs passive automations via `hooks/hooks.json`:
 - **SessionStart — hot cache restore.** Injects `wiki/hot.md` if `bootstrap_read_hot` is `"always"` (default: `"on-demand"`, read by skills on activation to save tokens).
 - **SessionStart — index auto-read.** Injects `wiki/index.md` if `bootstrap_read_index` is `"always"` (default: `"on-demand"`, read by skills on activation to avoid baseline token cost).
 - **PostCompact — hot cache restore.** Re-injects after context compaction.
-- **PostCompact — index auto-read.** Re-injects after context compaction.
+- **PostCompact — index auto-read.** Re-injects `wiki/index.md` after context compaction when `bootstrap_read_index` is `"always"`.
 - **PostToolUse (Edit | Write) — auto-commit.** Changes under `wiki/` and `.raw/` are committed to vault git.
 - **PostToolUse (Edit | Write) — scratch log.** Touched files logged for SessionEnd reflection.
 - **Stop — hot cache nudge.** If wiki changed, prompt to refresh `wiki/hot.md`.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ See `_shared/setup.md` for troubleshooting and Flatpak setup.
 The plugin auto-runs passive automations via `hooks/hooks.json`:
 
 - **SessionStart — hot cache restore.** Injects `wiki/hot.md` if `bootstrap_read_hot` is `"always"` (default: `"on-demand"`, read by skills on activation to save tokens).
+- **SessionStart — index auto-read.** Injects `wiki/index.md` if `bootstrap_read_index` is `"always"` (default: `"on-demand"`, read by skills on activation to avoid baseline token cost).
 - **PostCompact — hot cache restore.** Re-injects after context compaction.
+- **PostCompact — index auto-read.** Re-injects after context compaction.
 - **PostToolUse (Edit | Write) — auto-commit.** Changes under `wiki/` and `.raw/` are committed to vault git.
 - **PostToolUse (Edit | Write) — scratch log.** Touched files logged for SessionEnd reflection.
 - **Stop — hot cache nudge.** If wiki changed, prompt to refresh `wiki/hot.md`.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,6 +11,10 @@
           {
             "type": "command",
             "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; MODE=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-config.sh\" bootstrap_read_hot on-demand); if [ \"$MODE\" = \"always\" ] && [ -f \"$VAULT/wiki/hot.md\" ]; then cat \"$VAULT/wiki/hot.md\"; printf '\\n\\n[claude-obsidian] wiki/hot.md was injected above (bootstrap_read_hot=always). Silently absorb this context; do not announce it.\\n'; fi; exit 0"
+          },
+          {
+            "type": "command",
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; MODE=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-config.sh\" bootstrap_read_index on-demand); if [ \"$MODE\" = \"always\" ] && [ -f \"$VAULT/wiki/index.md\" ]; then cat \"$VAULT/wiki/index.md\"; printf '\\n\\n[claude-obsidian] wiki/index.md was injected above (bootstrap_read_index=always). Silently absorb this context; do not announce it.\\n'; fi; exit 0"
           }
         ]
       }
@@ -22,6 +26,10 @@
           {
             "type": "command",
             "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; MODE=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-config.sh\" bootstrap_read_hot on-demand); if [ \"$MODE\" = \"always\" ] && [ -f \"$VAULT/wiki/hot.md\" ]; then cat \"$VAULT/wiki/hot.md\"; printf '\\n\\n[claude-obsidian] wiki/hot.md was re-injected above after compaction (bootstrap_read_hot=always). Silently absorb this context to restore the hot cache; do not announce it.\\n'; fi; exit 0"
+          },
+          {
+            "type": "command",
+            "command": "VAULT=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh\") || exit 0; MODE=$(\"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-config.sh\" bootstrap_read_index on-demand); if [ \"$MODE\" = \"always\" ] && [ -f \"$VAULT/wiki/index.md\" ]; then cat \"$VAULT/wiki/index.md\"; printf '\\n\\n[claude-obsidian] wiki/index.md was re-injected above after compaction (bootstrap_read_index=always). Silently absorb this context to restore the index; do not announce it.\\n'; fi; exit 0"
           }
         ]
       }


### PR DESCRIPTION
## Context

Closes no specific issue. This change adds a `bootstrap_read_index` config option (mirroring the existing `bootstrap_read_hot`) that optionally injects `wiki/index.md` into the context at session start and after compaction.

Without this, Claude only has `hot.md` at startup — a recency-biased cache that misses cold-but-present pages. This caused Claude to incorrectly claim a topic was absent from the wiki when a full index lookup would have found it.

## Acceptance Criteria

- New `bootstrap_read_index` option in `.claude-plugin/plugin.json` with default `on-demand`
- Setting `"always"` injects `wiki/index.md` at `SessionStart` and re-injects it after `PostCompact`
- Existing `bootstrap_read_hot` behavior is unchanged
- JSON configs are valid

## Testing

Set `"bootstrap_read_index": "always"` in `~/.claude/settings.local.json` under the plugin options. Start a new Claude Code session — the index should be silently absorbed. Ask about a topic that is present in the index but absent from `hot.md`; Claude should recognize it without requiring an explicit `/query` call.