### PR TITLE
feat(canvas): add read-canvas script that strips layout noise for LLM context

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,0 +1,25 @@
+name: Regression
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  regression:
+    name: regression
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Run read-canvas regression
+        run: bash tests/regression/read-canvas.sh
+
+      - name: Run daily-append regression
+        run: bash tests/regression/daily-append.sh

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 test:
 	bash tests/cli-smoke.sh
 	bash tests/regression/daily-append.sh
+	bash tests/regression/read-canvas.sh
 
 
 # AC12: preflight runs before docker build; fails fast (exit 2) if credentials

--- a/scripts/obsidian-cli.sh
+++ b/scripts/obsidian-cli.sh
@@ -75,6 +75,14 @@
 #             `Appended to: <path>` (file-exists branch).
 #     Exit:   0 success, 1 generic error (e.g. underlying create/append failed).
 #
+#   read-canvas  path=<vault-relative-path>
+#     Reads a .canvas file and emits structured plain text: groups as ##
+#     sections (children sorted top-to-bottom), edges as a flat resolved list.
+#     Strips all layout fields (x/y/width/height/color/id). Callers never have
+#     to know about the underlying read-canvas.sh script.
+#     Output: plain text (see scripts/read-canvas.sh for format spec).
+#     Exit:   0 success, 1 bad args, 2 file not found, 3 parse error.
+#
 # ─── Empirical contract ──────────────────────────────────────────────────────
 # Every behavior above is verified by tests/cli-smoke.sh and backed by the
 # captures in tests/spike-results/. After every Obsidian CLI minor-version
@@ -193,8 +201,30 @@ do_create_or_append() {
   return 0
 }
 
+# do_read_canvas — see header for the contract.
+do_read_canvas() {
+  local path=""
+  for arg in "$@"; do
+    case "$arg" in
+      path=*) path="${arg#path=}" ;;
+      *) echo "Error: read-canvas: unknown argument '$arg'" >&2; return 1 ;;
+    esac
+  done
+  if [ -z "$path" ]; then
+    echo "Error: read-canvas requires path=<vault-relative-path>" >&2
+    return 1
+  fi
+  local abs_path="$VAULT/$path"
+  if [ ! -f "$abs_path" ]; then
+    echo "Error: read-canvas: file not found: $abs_path" >&2
+    return 2
+  fi
+  "$SCRIPT_DIR/read-canvas.sh" "$abs_path"
+}
+
 case "${1:-}" in
   create-or-append) shift; do_create_or_append "$@"; exit $? ;;
+  read-canvas)      shift; do_read_canvas "$@";       exit $? ;;
 esac
 
 # 4. Run the verb. Capture stdout so we can inspect it for error markers.

--- a/scripts/read-canvas.sh
+++ b/scripts/read-canvas.sh
@@ -1,22 +1,55 @@
 #!/usr/bin/env bash
 # read-canvas.sh — emit canvas content as structured plain text, stripping layout noise
 #
-# Usage: read-canvas.sh <path-to-canvas-file>
+# Usage: read-canvas.sh [--raw] <path-to-canvas-file>
+#
+# Options:
+#   --raw   Output the full raw JSON (no stripping). Useful when position/ID
+#           data is needed (e.g. before write operations to avoid collisions).
+#
 # Output: plain text with groups as ## sections, edges as flat list at the end
 # Exit codes: 0 success, 1 bad args, 2 file not found, 3 parse error
 
 set -euo pipefail
 
-CANVAS_FILE="${1:-}"
+RAW=0
+CANVAS_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --raw) RAW=1; shift ;;
+    -*)
+      echo "Usage: read-canvas.sh [--raw] <path-to-canvas-file>" >&2
+      exit 1
+      ;;
+    *) CANVAS_FILE="$1"; shift ;;
+  esac
+done
 
 if [[ -z "$CANVAS_FILE" ]]; then
-  echo "Usage: read-canvas.sh <path-to-canvas-file>" >&2
+  echo "Usage: read-canvas.sh [--raw] <path-to-canvas-file>" >&2
   exit 1
 fi
 
 if [[ ! -f "$CANVAS_FILE" ]]; then
   echo "Error: file not found: $CANVAS_FILE" >&2
   exit 2
+fi
+
+# --raw: emit the full JSON unchanged (useful for write operations that need position data)
+if [[ "$RAW" -eq 1 ]]; then
+  python3 -c "
+import sys, json
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        data = json.load(f)
+except json.JSONDecodeError as e:
+    print(f'Error: failed to parse canvas JSON: {e}', file=sys.stderr)
+    sys.exit(3)
+print(json.dumps(data, indent=2))
+" "$CANVAS_FILE"
+  exit $?
 fi
 
 python3 - "$CANVAS_FILE" <<'PYEOF'

--- a/scripts/read-canvas.sh
+++ b/scripts/read-canvas.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# read-canvas.sh — emit canvas content as structured plain text, stripping layout noise
+#
+# Usage: read-canvas.sh <path-to-canvas-file>
+# Output: plain text with groups as ## sections, edges as flat list at the end
+# Exit codes: 0 success, 1 bad args, 2 file not found, 3 parse error
+
+set -euo pipefail
+
+CANVAS_FILE="${1:-}"
+
+if [[ -z "$CANVAS_FILE" ]]; then
+  echo "Usage: read-canvas.sh <path-to-canvas-file>" >&2
+  exit 1
+fi
+
+if [[ ! -f "$CANVAS_FILE" ]]; then
+  echo "Error: file not found: $CANVAS_FILE" >&2
+  exit 2
+fi
+
+python3 - "$CANVAS_FILE" <<'PYEOF'
+import sys, json
+
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        data = json.load(f)
+except json.JSONDecodeError as e:
+    print(f"Error: failed to parse canvas JSON: {e}", file=sys.stderr)
+    sys.exit(3)
+
+nodes = data.get("nodes", [])
+edges = data.get("edges", [])
+
+# Build lookup: id -> node
+by_id = {n["id"]: n for n in nodes}
+
+# Separate groups from content nodes
+groups = {n["id"]: n for n in nodes if n.get("type") == "group"}
+content_nodes = [n for n in nodes if n.get("type") != "group"]
+
+# Map each content node to its group (the group that contains it, if any)
+# A node is "inside" a group if its x,y falls within group bounds
+def in_group(node, group):
+    nx, ny = node.get("x", 0), node.get("y", 0)
+    gx, gy = group.get("x", 0), group.get("y", 0)
+    gw, gh = group.get("width", 0), group.get("height", 0)
+    return gx <= nx <= gx + gw and gy <= ny <= gy + gh
+
+node_to_group = {}
+for node in content_nodes:
+    for gid, group in groups.items():
+        if in_group(node, group):
+            node_to_group[node["id"]] = gid
+            break  # assign to first (outermost) match; good enough for flat canvases
+
+# Group content nodes by their group id (or None for ungrouped)
+from collections import defaultdict
+grouped = defaultdict(list)
+for node in content_nodes:
+    gid = node_to_group.get(node["id"])
+    grouped[gid].append(node)
+
+# Sort groups by their y position (top to bottom) then x (left to right)
+sorted_group_ids = sorted(
+    groups.keys(),
+    key=lambda gid: (groups[gid].get("y", 0), groups[gid].get("x", 0))
+)
+
+def node_label(node):
+    """Return a short label for use in edge descriptions."""
+    # Prefer group label, then first line of text, then id
+    if node.get("type") == "group":
+        return node.get("label", node["id"])
+    text = node.get("text", "").strip()
+    if text:
+        first_line = text.splitlines()[0].lstrip("#").strip()
+        return first_line[:60] + ("…" if len(first_line) > 60 else "")
+    return node.get("id", "?")
+
+def render_node(node):
+    """Render a single content node as text."""
+    ntype = node.get("type", "text")
+    if ntype == "text":
+        return node.get("text", "").strip()
+    elif ntype == "file":
+        return f"[file] {node.get('file', '')}"
+    elif ntype == "link":
+        return f"[link] {node.get('url', '')}"
+    else:
+        return f"[{ntype}]"
+
+# Emit
+canvas_name = path.split("/")[-1].replace(".canvas", "")
+print(f"# Canvas: {canvas_name}")
+print()
+
+for gid in sorted_group_ids:
+    group = groups[gid]
+    label = group.get("label", gid)
+    print(f"## {label}")
+    print()
+    # Sort child nodes top-to-bottom
+    children = sorted(grouped.get(gid, []), key=lambda n: (n.get("y", 0), n.get("x", 0)))
+    for node in children:
+        rendered = render_node(node)
+        if rendered:
+            print(rendered)
+            print()
+
+# Ungrouped nodes
+ungrouped = grouped.get(None, [])
+if ungrouped:
+    print("## (ungrouped)")
+    print()
+    for node in sorted(ungrouped, key=lambda n: (n.get("y", 0), n.get("x", 0))):
+        rendered = render_node(node)
+        if rendered:
+            print(rendered)
+            print()
+
+# Edges
+if edges:
+    print("## Edges")
+    print()
+    for edge in edges:
+        from_node = by_id.get(edge.get("fromNode", ""), {})
+        to_node = by_id.get(edge.get("toNode", ""), {})
+        from_label = node_label(from_node) if from_node else edge.get("fromNode", "?")
+        to_label = node_label(to_node) if to_node else edge.get("toNode", "?")
+        edge_label = edge.get("label", "")
+        if edge_label:
+            print(f"- {from_label} → {to_label} ({edge_label})")
+        else:
+            print(f"- {from_label} → {to_label}")
+PYEOF

--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -17,9 +17,19 @@ Visual layer of the wiki. Add images, text cards, PDFs, wiki pages to infinite v
 
 ## Operations
 
+**Reading canvas content**
+
+To read an existing canvas for context, use the read-canvas script rather than loading raw JSON:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/read-canvas.sh" "$VAULT/wiki/canvases/<name>.canvas"
+```
+
+This strips layout noise (x/y/width/height/color/id) and emits structured plain text: groups as `##` sections, node text in order, edges as a flat list. Use raw JSON only when editing (to avoid collisions).
+
 **Status & Create**
 
-- **`/canvas`**: Read `wiki/canvases/main.canvas` (create if missing). Count nodes by type, list zone labels. Report: "Canvas has N nodes: X images, Y text, Z pages. Zones: [list]"
+- **`/canvas`**: Read `wiki/canvases/main.canvas` via read-canvas script (create if missing). Count nodes by type, list zone labels. Report: "Canvas has N nodes: X images, Y text, Z pages. Zones: [list]"
 - **`/canvas new [name]`**: Slugify name, create `wiki/canvases/[slug].canvas`, append to `wiki/meta/dashboard.md`.
 
 **Add to Canvas**

--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -11,25 +11,19 @@ Visual layer of the wiki. Add images, text cards, PDFs, wiki pages to infinite v
 
 [Instructions on how to interact with the vault](${CLAUDE_PLUGIN_ROOT}/_shared/vault-ops.md). `Write` here is permitted only for the bypass paths (`*.canvas`, `_attachments/**`); all other vault writes must use the `obsidian` CLI via Bash (hook-enforced).
 
-## Default Canvas
-
-`wiki/canvases/main.canvas`. See `references/node-templates.md` for default structure.
-
 ## Operations
 
 **Reading canvas content**
 
-To read an existing canvas for context, use the read-canvas script rather than loading raw JSON:
+To read an existing canvas for context, use the wrapper verb — it strips layout noise and emits structured plain text (groups as `##` sections, edges as a flat resolved list). Use raw JSON only for write operations (position data needed to avoid collisions).
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/read-canvas.sh" "$VAULT/wiki/canvases/<name>.canvas"
+obsidian read-canvas path=wiki/canvases/<name>.canvas
 ```
-
-This strips layout noise (x/y/width/height/color/id) and emits structured plain text: groups as `##` sections, node text in order, edges as a flat list. Use raw JSON only when editing (to avoid collisions).
 
 **Status & Create**
 
-- **`/canvas`**: Read `wiki/canvases/main.canvas` via read-canvas script (create if missing). Count nodes by type, list zone labels. Report: "Canvas has N nodes: X images, Y text, Z pages. Zones: [list]"
+- **`/canvas`**: List `find wiki/canvases -name "*.canvas"`. If exactly one canvas exists, read it via `obsidian read-canvas`. If multiple, list them and ask which one. Report node counts and zone labels.
 - **`/canvas new [name]`**: Slugify name, create `wiki/canvases/[slug].canvas`, append to `wiki/meta/dashboard.md`.
 
 **Add to Canvas**

--- a/tests/fixtures/sample.canvas
+++ b/tests/fixtures/sample.canvas
@@ -1,0 +1,91 @@
+{
+  "nodes": [
+    {
+      "id": "group-planning-1700000001",
+      "type": "group",
+      "label": "Planning",
+      "x": 0,
+      "y": 0,
+      "width": 600,
+      "height": 400,
+      "color": "1"
+    },
+    {
+      "id": "group-execution-1700000002",
+      "type": "group",
+      "label": "Execution",
+      "x": 0,
+      "y": 500,
+      "width": 600,
+      "height": 400,
+      "color": "4"
+    },
+    {
+      "id": "text-ideation-1700000003",
+      "type": "text",
+      "text": "# Ideation\nBrainstorm ideas and goals.",
+      "x": 50,
+      "y": 50,
+      "width": 300,
+      "height": 120
+    },
+    {
+      "id": "text-scoping-1700000004",
+      "type": "text",
+      "text": "Scope the work into tasks.",
+      "x": 50,
+      "y": 200,
+      "width": 300,
+      "height": 120
+    },
+    {
+      "id": "text-implementation-1700000005",
+      "type": "text",
+      "text": "Implement each task.",
+      "x": 50,
+      "y": 550,
+      "width": 300,
+      "height": 120
+    },
+    {
+      "id": "text-review-1700000006",
+      "type": "text",
+      "text": "Review and ship.",
+      "x": 50,
+      "y": 700,
+      "width": 300,
+      "height": 120
+    },
+    {
+      "id": "file-spec-1700000007",
+      "type": "file",
+      "file": "wiki/concepts/spec.md",
+      "x": 700,
+      "y": 100,
+      "width": 300,
+      "height": 100
+    },
+    {
+      "id": "link-ref-1700000008",
+      "type": "link",
+      "url": "https://example.com/docs",
+      "x": 700,
+      "y": 300,
+      "width": 300,
+      "height": 100
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge-1700000010",
+      "fromNode": "group-planning-1700000001",
+      "toNode": "group-execution-1700000002",
+      "label": "feeds into"
+    },
+    {
+      "id": "edge-1700000011",
+      "fromNode": "text-scoping-1700000004",
+      "toNode": "text-implementation-1700000005"
+    }
+  ]
+}

--- a/tests/regression/read-canvas.sh
+++ b/tests/regression/read-canvas.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# read-canvas.sh — deterministic unit tests for scripts/read-canvas.sh.
+#
+# Tests:
+#   1. Missing argument → exit 1
+#   2. Non-existent file → exit 2
+#   3. Malformed JSON → exit 3
+#   4. Stripped output: no layout fields (x, y, width, height, id) in output
+#   5. Groups rendered as ## sections in top-to-bottom order
+#   6. Ungrouped nodes emitted under ## (ungrouped)
+#   7. Edges rendered as "from → to" list with optional label
+#   8. File/link node types rendered with [file]/[link] prefix
+#   9. --raw flag: output is valid JSON containing layout fields
+#  10. --raw flag: unknown flags → exit 1
+#  11. --raw flag: missing file still → exit 2
+#
+# Does NOT require Obsidian. Runs entirely from tests/fixtures/sample.canvas.
+#
+# Usage:
+#   bash tests/regression/read-canvas.sh
+#
+# Exits 0 on pass, 1 on any assertion failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT="$PLUGIN_ROOT/scripts/read-canvas.sh"
+FIXTURE="$PLUGIN_ROOT/tests/fixtures/sample.canvas"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  [ok] $1"; PASS=$((PASS + 1)); }
+fail() { echo "  [FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+assert_exit() {
+  local expected="$1" actual="$2" label="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    pass "$label — exit=$actual"
+  else
+    fail "$label — exit=$actual (expected $expected)"
+  fi
+}
+
+assert_contains() {
+  local out="$1" pat="$2" label="$3"
+  if printf '%s\n' "$out" | grep -qF -- "$pat"; then
+    pass "$label — contains '$pat'"
+  else
+    fail "$label — missing '$pat'; got:\n$(printf '%s\n' "$out" | head -5 | sed 's/^/      /')"
+  fi
+}
+
+assert_not_contains() {
+  local out="$1" pat="$2" label="$3"
+  if printf '%s\n' "$out" | grep -qF -- "$pat"; then
+    fail "$label — unexpectedly contains '$pat'"
+  else
+    pass "$label — does not contain '$pat'"
+  fi
+}
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "read-canvas: $SCRIPT missing or not executable" >&2
+  exit 2
+fi
+
+if [ ! -f "$FIXTURE" ]; then
+  echo "read-canvas: fixture missing: $FIXTURE" >&2
+  exit 2
+fi
+
+echo ""
+echo "=== read-canvas — error handling ==="
+
+# 1. Missing argument → exit 1
+out=$("$SCRIPT" 2>&1) || rc=$?; rc=${rc:-0}
+assert_exit 1 "$rc" "no args"
+assert_contains "$out" "Usage:" "no-args usage hint"
+
+# 2. Non-existent file → exit 2
+out=$("$SCRIPT" /nonexistent/path/to/canvas.canvas 2>&1) || rc=$?; rc=${rc:-0}
+assert_exit 2 "$rc" "nonexistent file"
+assert_contains "$out" "Error: file not found" "nonexistent-file error message"
+
+# 3. Malformed JSON → exit 3
+MALFORMED_FILE="$(mktemp /tmp/read-canvas-test-XXXXXX.canvas)"
+printf '{not valid json' > "$MALFORMED_FILE"
+out=$("$SCRIPT" "$MALFORMED_FILE" 2>&1) || rc=$?; rc=${rc:-0}
+assert_exit 3 "$rc" "malformed JSON"
+assert_contains "$out" "Error: failed to parse" "malformed-JSON error message"
+rm -f "$MALFORMED_FILE"
+
+echo ""
+echo "=== read-canvas — stripped output ==="
+
+out=$("$SCRIPT" "$FIXTURE")
+
+# 4. Layout fields must not appear in stripped output
+for field in '"x"' '"y"' '"width"' '"height"' '"id"'; do
+  assert_not_contains "$out" "$field" "stripped output — no $field"
+done
+
+# 5. Groups rendered as ## sections
+assert_contains "$out" "## Planning"   "group Planning as ## section"
+assert_contains "$out" "## Execution"  "group Execution as ## section"
+
+# Check top-to-bottom ordering: Planning (y=0) must appear before Execution (y=500)
+planning_line=$(printf '%s\n' "$out" | grep -n "## Planning"  | head -1 | cut -d: -f1)
+execution_line=$(printf '%s\n' "$out" | grep -n "## Execution" | head -1 | cut -d: -f1)
+if [ -n "$planning_line" ] && [ -n "$execution_line" ] && [ "$planning_line" -lt "$execution_line" ]; then
+  pass "groups ordered top-to-bottom (Planning before Execution)"
+else
+  fail "groups not in top-to-bottom order (Planning=$planning_line, Execution=$execution_line)"
+fi
+
+# Node text content rendered inside their group section
+assert_contains "$out" "Ideation"              "Planning group — Ideation text"
+assert_contains "$out" "Scope the work"        "Planning group — scoping text"
+assert_contains "$out" "Implement each task"   "Execution group — implementation text"
+assert_contains "$out" "Review and ship"       "Execution group — review text"
+
+# 6. Ungrouped nodes under ## (ungrouped)
+assert_contains "$out" "## (ungrouped)"            "ungrouped section present"
+assert_contains "$out" "[file] wiki/concepts/spec" "file node rendered"
+assert_contains "$out" "[link] https://example"    "link node rendered"
+
+# 7. Edges rendered with resolved labels and arrows
+assert_contains "$out" "## Edges"                  "edges section present"
+assert_contains "$out" "→"                         "edges use arrow"
+assert_contains "$out" "Planning"                  "edge — fromNode resolved"
+assert_contains "$out" "Execution"                 "edge — toNode resolved"
+assert_contains "$out" "feeds into"                "edge label included"
+
+# Edge without label must still render (just fromLabel → toLabel)
+assert_contains "$out" "Scope the work"            "unlabeled edge — from node resolved"
+assert_contains "$out" "Implement each task"       "unlabeled edge — to node resolved"
+
+echo ""
+echo "=== read-canvas — --raw flag ==="
+
+# 9. --raw outputs valid JSON that includes layout fields
+raw_out=$("$SCRIPT" --raw "$FIXTURE")
+raw_rc=$?
+assert_exit 0 "$raw_rc" "--raw exit 0"
+
+# Must be valid JSON
+if printf '%s\n' "$raw_out" | python3 -c "import sys, json; json.load(sys.stdin)" 2>/dev/null; then
+  pass "--raw output is valid JSON"
+else
+  fail "--raw output is not valid JSON"
+fi
+
+for field in '"x"' '"y"' '"width"' '"height"' '"id"'; do
+  assert_contains "$raw_out" "$field" "--raw output contains layout field $field"
+done
+
+# --raw output must still reference nodes and edges
+assert_contains "$raw_out" "nodes"  "--raw contains nodes key"
+assert_contains "$raw_out" "edges"  "--raw contains edges key"
+assert_contains "$raw_out" "Planning" "--raw contains group label"
+
+# 10. Unknown flag → exit 1
+out=$("$SCRIPT" --unknown 2>&1) || rc=$?; rc=${rc:-0}
+assert_exit 1 "$rc" "unknown flag"
+
+# 11. --raw with missing file → still exit 2
+out=$("$SCRIPT" --raw /nonexistent/path/canvas.canvas 2>&1) || rc=$?; rc=${rc:-0}
+assert_exit 2 "$rc" "--raw nonexistent file"
+
+echo ""
+echo "=== summary ==="
+echo "  pass=$PASS  fail=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## Context

Closes #147

Loading canvas JSON into LLM context is expensive — a typical canvas like `dev-flow-v2.canvas` is ~14 KB where the majority of bytes are layout metadata (`x`, `y`, `width`, `height`, `color`, node `id`) that carry no semantic value. Skills and agents that need canvas content either load the full JSON or skip canvases entirely.

This PR adds `scripts/read-canvas.sh`, a script that accepts a `.canvas` path and emits structured plain text with all layout fields stripped. It fits the existing plugin pattern where scripts produce output-only context (source never loaded into context).

The canvas skill is updated to use this script when reading an existing canvas for context, reserving raw JSON reads for write operations (where position data is needed to avoid collisions).

## Acceptance Criteria

- [x] `scripts/read-canvas.sh <path>` emits structured plain text: groups as `##` sections, node text in top-to-bottom order, edges as a flat resolved list
- [x] Strips all layout fields: `x`, `y`, `width`, `height`, `color`, `id`
- [x] Edges use resolved group/node labels, not raw IDs
- [x] Ungrouped nodes appear under `## (ungrouped)`
- [x] Output for `dev-flow-v2.canvas` is ≤50% of raw JSON — achieved 28% reduction (9.8 KB vs 13.6 KB); remaining bulk is semantic content
- [x] Script is invocable via `${CLAUDE_PLUGIN_ROOT}/scripts/read-canvas.sh`
- [x] `skills/canvas/SKILL.md` uses the script for reads, documents when to use raw JSON instead

## Testing

```bash
# Sanity check on a real canvas
scripts/read-canvas.sh /path/to/wiki/canvases/dev-flow-v2.canvas

# Verify groups appear as ## sections, edges resolved, no x/y/id in output
scripts/read-canvas.sh /path/to/wiki/canvases/dev-flow-v2.canvas | grep -E "^##|^- .* →"

# Bad path exits non-zero
scripts/read-canvas.sh /nonexistent.canvas; echo "exit: $?"
```