### PR TITLE
feat: add git-cliff changelog handling (#152)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,20 @@ jobs:
           jq --arg v "$v" '.metadata.version = $v | .plugins[0].version = $v' .claude-plugin/marketplace.json > "$tmp"
           mv "$tmp" .claude-plugin/marketplace.json
 
+      - name: Install Node dependencies
+        run: |
+          npm ci
+
+      - name: Update CHANGELOG.md
+        run: |
+          set -euo pipefail
+          sed -i '/^## \[Unreleased\]/,/^## \[/{/^## \[Unreleased\]/d;/^## \[/!d}' CHANGELOG.md
+          git cliff --tag "${{ steps.bump.outputs.tag }}" --prepend CHANGELOG.md
+
       - name: Commit, tag, push
         run: |
           set -euo pipefail
-          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
+          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json CHANGELOG.md
           git commit -m "chore: release ${{ steps.bump.outputs.tag }}"
           git tag -a "${{ steps.bump.outputs.tag }}" -m "${{ steps.bump.outputs.tag }}"
           git push origin HEAD
@@ -80,11 +90,15 @@ jobs:
             "${{ steps.bump.outputs.tag }}"
           echo "artifact=$file" >> "$GITHUB_ENV"
 
+      - name: Generate release body
+        run: |
+          git cliff --latest --strip header > /tmp/release-body.md
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "${{ steps.bump.outputs.tag }}" \
             --title "${{ steps.bump.outputs.tag }}" \
-            --generate-notes \
+            --notes-file /tmp/release-body.md \
             "$artifact"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,203 +2,169 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
 
+- Add read-head, grep, and grep-files wrapper verbs for context-saving vault reads
+- Switch license from MIT to PolyForm Noncommercial 1.0.0
+
+### Fixed
+
+- Clarify mandatory steps and update index mapping for note types
+## [1.8.0] - 2026-05-21
 ### Added
 
-- `bootstrap_read_index` option to auto-inject `wiki/index.md` at session start and after context compaction when set to `"always"` (mirrors `bootstrap_read_hot`).
-- **`agents/capture.md`** — single CAPTURE-pipeline worker; files one atomic inbox note per invocation. Used by `braindump` for parallel chunk dispatch (#118).
-- **`agents/research-round.md`** — runs one depth-≥2 research branch (search + fetch + source-synth dispatch). Used by `autoresearch` for Round 2 gap-fill and Round 3 synthesis-check phases (#118).
-- **`agents/source-synth.md`** — synthesises one fetched source into wiki pages (entities, concepts, source summary). Used by `autoresearch` and `research-round` (#118).
-- **`agents/gather.md`** — read-only sweep agent; reads a cluster of vault files and returns a structured summary. Used by `daily-close` (dated-page sweep) and `query` deep mode (per-cluster page reads) (#118).
+- Add read-canvas script that strips layout noise for LLM context
 
 ### Changed
 
-- **`skills/ingest/SKILL.md`** — single-source path now dispatches `agents/ingest.md` after the interactive discussion; batch path fans out one agent per source in parallel (#118).
-- **`skills/lint/SKILL.md`** — added explicit **Agent Dispatch** section; main thread runs `lint-scan.sh` then dispatches `agents/lint.md`; report-rotation note updated to reference the dispatch block (#118).
-- **`skills/braindump/SKILL.md`** — added **CAPTURE loop** dispatch table; 5+ independent chunks (or 2–4 independent chunks) fan out to `agents/capture.md` in parallel; sequential/order-sensitive paths remain inline (#118).
-- **`skills/autoresearch/SKILL.md`** — added agent-dispatch overview table; Round 1 stays inline; Round 1 source filing fans out `source-synth` agents; Round 2 gap-fill fans out `research-round` agents; Round 3 uses a single `research-round` dispatch (#118).
-- **`skills/daily-close/SKILL.md`** — step 5 dispatches `agents/gather.md` for the dated-page read sweep when more than 3 files are matched; small sweeps remain inline (#118).
-- **`skills/query/SKILL.md`** — deep mode step 5 dispatches one `agents/gather.md` per page cluster (> 5 candidates) in parallel; smaller candidate sets remain inline (#118).
+- Release v1.8.0
+## [1.7.2] - 2026-05-17
+### Changed
 
-## [1.1.0] — 2026-05-03
+- Release v1.7.2
+- Simplify command detection and verb extraction
+## [1.7.1] - 2026-05-17
+### Changed
 
+- Release v1.7.1
+- Active vault I/O enforcement + skill / shared-doc consolidation
+## [1.7.0] - 2026-05-15
+### Changed
+
+- Release v1.7.0
+- Extract inline content to reference files, bring SKILL.md to 50-line cap
+
+### Documentation
+
+- Establish lazy-loading standard for skill reference files
+## [1.6.0] - 2026-05-15
 ### Added
 
-- **E2E harness — CI fast tier.** `Dockerfile` and a GitHub Actions workflow that runs the smoke-test suite on every PR, against a pinned Obsidian image (#92).
-- **E2E harness — local full tier.** Entrypoint script, expanded assertions, and a `Makefile` so contributors run the same suite locally that CI runs (#94).
-- **Lint check #15** — flags index entries placed under the wrong type heading as misplaced (#87).
-- **Backlink-aware traversal** in `/query` and `/lint`, with a density check that surfaces over- and under-linked clusters (#78).
-- **`/autoresearch` trail page** recording the argument order of each run, so reruns can be replayed and audited (#93).
-- **Initial lint report for wiki metadata validation** — programmatic frontmatter pass that feeds the lint dashboard.
+- Add bootstrap_read_index option to auto-inject wiki/index.md at session start
 
 ### Changed
 
-- **Unified domain hub architecture.** Wiki content is reorganized around domain hubs instead of ad-hoc category folders; closes the long-standing #46 reorganization. Existing pages were migrated in place (#79).
-- **Vault housekeeping** — slug-generation bug fix, lint-report rotation, and seed-onboarding refinements (#83).
-- **`/save` index insert** is now section-aware: index updates splice into the correct section instead of prepending to the whole file, which had been disturbing surrounding content (#86).
-- **`/daily` capture path** uses atomic CLI verbs (`append` / `prepend`) instead of read-modify-write, eliminating bullet loss when concurrent captures land in the same daily note (#103).
-- `_seed/FIRST_RUN.md` no longer references the removed `Wiki Map.canvas` (#88).
+- Release v1.6.0
 
 ### Fixed
 
-- **`/lint` dead-link check** is now deterministic — replaced the inline scan with `lint-scan.sh`, which produces stable output across runs (#102).
-- **`commands/` directory registered in the plugin manifest** so slash commands appear in Claude Code's menu without depending on auto-discovery quirks (#99).
+- Enforce obsidian CLI for vault ops in agents and skills
+## [1.5.2] - 2026-05-15
+### Changed
 
-[Full diff](https://github.com/misiekhardcore/claude-obsidian/compare/v1.0.0...v1.1.0)
+- Release v1.5.2
+- Remove session scratch log file
 
-## [1.0.0] — 2026-04-29
+### Fixed
 
-Closes the CLI migration epic (#48). With this release, **all** vault I/O across every skill and hook routes through the Obsidian CLI; the Local REST API + MCP code path is gone.
+- Replace jq filter with grep -E for plain-text files output
+- Fix backlinks unbound variable under set -u
+## [1.5.1] - 2026-05-15
+### Changed
 
-### Breaking Changes
+- Release v1.5.1
 
-- **Obsidian 1.12.7+ is now a hard prerequisite.** The plugin no longer ships any non-CLI vault-access path. Sessions still start when Obsidian is closed (the SessionStart probe is fail-soft), but skills that touch the vault will error until Obsidian is running with the registered vault open.
-- **MCP server `obsidian-vault` is fully removed.** No skill, hook, script, or shared reference still calls `mcp__obsidian-vault__*`. Setup docs no longer mention the Local REST API community plugin, the Tray plugin, or the `NODE_TLS_REJECT_UNAUTHORIZED=0` workaround.
-- **For external plugin authors:** the `mcp__obsidian-vault__*` tool surface is gone in 1.0.0. Migrate to the `obsidian` CLI via Bash; see `_shared/cli.md` for the empirical contract (exit codes, output formats, escape-hatch policy) and `skills/wiki/references/cli-setup.md` for end-to-end examples (#53).
+### Fixed
+
+- Resolve plugin root from script location, not CLAUDE_PLUGIN_ROOT
+## [1.5.0] - 2026-05-14
+### Added
+
+- Log obsidian cli usage
 
 ### Changed
 
-- `_seed/FIRST_RUN.md` no longer instructs new users to install Local REST API or Tray. Templater remains the only required community plugin; CLI registration is the new third step (#53).
-- `_shared/capture-pipeline.md` and `skills/notes/SKILL.md` now use `obsidian properties path=<file>` for frontmatter scans (the `properties` verb has no `format=json` support — fix references the empirical contract in `_shared/cli.md` §3) (#53).
-- `skills/wiki/references/cli-setup.md` Examples section is filled with end-to-end snippets for ingest, query, save, and the lint primitives surfaced by the CLI (`orphans`, `deadends`, `unresolved`, `backlinks`) (#53).
-- `skills/daily/SKILL.md`, `skills/daily-close/SKILL.md`, `skills/braindump/SKILL.md`, and `skills/obsidian-bases/SKILL.md` now route every vault read and write through the `obsidian` CLI. `Write` and `Edit` are dropped from `allowed-tools`; atomic frontmatter rewrites use `obsidian create overwrite=true`; date-matched activity scans use `obsidian properties path=<file>` per candidate (#53).
-- `skills/obsidian-markdown/SKILL.md` `allowed-tools` trimmed to `Read` — this is a reference-text-only skill, never writes vault pages (#53).
-- `commands/wiki.md` SCAFFOLD step 3 no longer probes for an MCP server; it now checks vault registration via `obsidian list vaults` (#53).
-- `_shared/vault-structure.md` solution-page example renamed from `configure-mcp-server` to `register-vault-with-cli` (#53).
-- `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` bumped to `1.0.0` (#53).
-- `README.md` and `CLAUDE.md` skill listings now include `daily-close` (shipped in #69 but missed by both inventories) (#53).
+- Release v1.5.0
+## [1.4.0] - 2026-05-12
+### Changed
 
+- Release v1.4.0
+- Improve skill authoring quality: when_to_use, trim oversized skills, modularity
+
+### Documentation
+
+- Add cross-plugin scope boundary section to AUTHORING.md
+## [1.3.0] - 2026-05-07
 ### Added
 
-- `commands/daily-close.md` and `commands/braindump.md` — slash-command stub files for `/daily-close` and `/braindump`. Both skills already advertised those triggers; without the command files they only auto-loaded via skill-description match and didn't appear in Claude Code's slash menu (#53).
-
-### Migration
-
-1. Confirm you are on Obsidian 1.12.7 or newer.
-2. If you skipped 0.5.0: register your vault with the CLI once — `obsidian register vault=/absolute/path/to/vault`.
-3. Optional cleanup of stale background state from older releases:
-   ```bash
-   pkill -f mcp-obsidian
-   ```
-   You can also disable or uninstall the Local REST API community plugin if nothing else on your machine uses it.
-4. No vault-side migrations required; existing wiki content is read/written unchanged.
-
-### Rollback
-
-If a regression blocks your work, pin the previous release:
-
-```bash
-/plugin install claude-obsidian@0.5.1
-```
-
-For a fully MCP-based rollback (no CLI dependency at all), pin `0.4.0`, re-enable the Local REST API community plugin, and follow the legacy `mcp-setup.md` (preserved in git history at the `v0.4.0` tag).
-
-## [0.5.1] — 2026-04-27
-
-### Fixed
-
-- **SessionStart and PostCompact hooks** rewritten from prompt-type to command-type, eliminating the `ToolUseContext` error that fired on every session start under recent Claude Code builds (#58).
-
-[Full diff](https://github.com/misiekhardcore/claude-obsidian/compare/v0.5.0...v0.5.1)
-
-## [0.5.0] — 2026-04-26
-
-### Breaking Changes
-
-`query` and `save` now talk to Obsidian through the official Obsidian CLI (1.12.7+) instead of the Local REST API + MCP server. The vault must be open in a running Obsidian desktop instance for these two skills to read or write (#54).
-
-The remaining vault-touching skills (`ingest`, `lint`, `notes`, `canvas`, `obsidian-bases`, `wiki`, `autoresearch`, `defuddle`) keep their existing direct-file / MCP behaviour and will be migrated in follow-up sub-issues. Mixed-mode coexistence is intentional — you do not need to wait for the full migration.
-
-### Added
-
-- `scripts/obsidian-cli.sh` — wrapper that resolves the vault, derives the vault name (`basename`), pre-flights `obsidian version`, and normalizes exit codes. Contract is documented inline in the script's header comment: exit-code table, error patterns, escape-hatch policy, and the documented exception list (#54).
-- `scripts/cli-spike.sh` — empirical CLI probe; results pinned in `tests/spike-results/`. Re-run after every Obsidian CLI minor-version bump (#54).
-- `tests/cli-smoke.sh` — 15 assertions on wrapper output shape and exit codes against the active vault (#54).
-- `tests/fixtures/vault/` — minimal Obsidian vault used by the spike and future skill smoke tests (#54).
-- SessionStart hook entry that pre-flights `obsidian version` and emits an actionable warning when Obsidian is missing or stopped (fail-soft — never blocks the session) (#54).
-- `hooks/obsidian-cli-rewrite.sh` — PreToolUse hook (matcher: `Bash`) that transparently rewrites raw `obsidian <verb>` invocations to call `scripts/obsidian-cli.sh` instead. RTK-style transparent rewrite via `hookSpecificOutput.updatedInput.command`. Conservative match: first token must be exactly `obsidian`; commands already mentioning `obsidian-cli` are untouched (#54).
+- Add when_to_use to multi-mode skills and expand AUTHORING.md (PR3)
+- Remove Glob/Grep from 11 skills, drop obsidian-markdown allowed-tools, add disallowedTools to agents (PR2)
+- Add Agent/WebFetch to allowed-tools and argument-hint to commands (PR1)
 
 ### Changed
 
-- `skills/query/SKILL.md` — vault reads now go through `obsidian-cli.sh read path=...`. `Read` is retained for non-vault resources only. `allowed-tools` adds `Bash` (#54).
-- `skills/save/SKILL.md` — vault reads, creates, appends, prepends, and overwrites go through the wrapper. `Write` and `Edit` are no longer in `allowed-tools` (the wrapper covers all vault writes) (#54).
-- Trimmed wrapper-usage repetition from `query` and `save` SKILL.md — vault I/O conventions live in `CLAUDE.md` and `_shared/`, the skills no longer duplicate them (#59).
-- No new `userConfig` keys; the SessionStart version probe is unconditional and fail-soft (#54).
-
-### Fixed
-
-- SessionEnd reflection hook restored on dash-based `/bin/sh`. The 0.4.0 fix used `nohup … & disown`, but `disown` is a bash builtin and dash aborts the script before the reflection runs. Dropping `disown` keeps the subshell detached enough to avoid SessionEnd cancellation while staying POSIX-compatible (#57).
-
-### Migration
-
-1. Install Obsidian 1.12.7 or newer.
-2. Enable the Obsidian CLI (Settings → Community plugins → Obsidian CLI; or follow the upstream install instructions).
-3. Make sure Obsidian is running with your vault open before starting a Claude Code session that uses `query` or `save`. The SessionStart hook prints a warning to stderr if it is not — sessions still continue.
-4. No vault-side migrations are required; existing wiki content is read/written unchanged.
-
-### Empirical findings worth knowing
-
-These came out of `scripts/cli-spike.sh` and are pinned in the wrapper / smoke header comments:
-
-- The Obsidian CLI **always returns exit 0**, regardless of success or failure. The wrapper detects errors by inspecting the first line of stdout (`Error: ...` or `Vault not found.`).
-- `vault=<name>` accepts a vault **name** (basename), not a path. `vault=/some/path` returns `Vault not found.`
-- `orphans`, `deadends`, `tasks`, and `properties` do not accept `format=json`; only `backlinks`, `tags`, `unresolved`, `outline`, `search`, `bookmarks`, and `aliases` do. The format-defaults table in `tests/cli-smoke.sh` reflects this.
-- Multiline `content="line one\nline two"` round-trips cleanly through `create` + `read`. No `source=/tmp/...` fallback is needed for hot-cache rewrites.
-
-### Rollback
-
-If a regression blocks your work, pin the previous release:
-
-```bash
-/plugin install claude-obsidian@0.4.0
-```
-
-The 0.4.0 plugin re-enables the Local REST API + MCP code path. After pinning, you can optionally `pkill -f mcp-obsidian` if a stale MCP server is still running from before the upgrade.
-
-## [0.4.0] — 2026-04-26
-
+- Release v1.3.0
+- Move empty-sections check to lint-scan.sh
+## [1.2.0] - 2026-05-07
 ### Added
 
-- `bootstrap_read_hot` config key (`always` | `on-demand` | `never`, default `on-demand`) gates `wiki/hot.md` injection at SessionStart and PostCompact, saving ~2–3k tokens/turn for non-wiki sessions (#43, closes #25).
-
-### Fixed
-
-- SessionEnd reflection hook no longer prints `Hook cancelled`. The synchronous `claude -p` subprocess exceeded Claude Code's exit deadline; the hook now detaches via `nohup … & disown` so it returns instantly while the reflection still writes to the daily note (#56, closes #55).
-
-## [0.3.0] — 2026-04-25
-
-### Added
-
-- `/note` skill for inbox capture and triage: verbatim quick-capture, silent auto-match append on overlap, list and process flows for triaging (#42).
-- Demo vault seeded on `/wiki init` so new users see a populated structure on first run (#40, closes #34).
-- `wiki-lint` now checks `wiki/hot.md` against the 500-word size budget (#38, closes #24).
-
-### Fixed
-
-- Hooks no longer pass `${user_config.vault_path}` directly; the resolver owns vault path resolution (#37).
-
-## [0.2.0] — 2026-04-24
-
-### Added
-
-- Release workflow in CI (#35).
-- Cross-skill documentation extracted into `_shared/` for reuse across skills (#30).
-- Scheduled lint nudge and passive vault reflection hooks (#19).
-- `/wiki init` wired to `setup-vault.sh` with absolute vault path support and `_templates/` (#18, #15).
-- `resolve-vault.sh` helper plus hook rewrite to use `${user_config.vault_path}` for vault path resolution (#14).
-- 10 skills, 4 commands, and 2 agents migrated from `claude-config/memory` into the plugin (#12).
-- `.claude-plugin` manifests with `userConfig` for vault path (#11).
-- README install, skills, and vault structure sections (#28, #23).
+- Sub-agent dispatch for capture/ingest/research/lint skills
+- Update query skill documentation for clarity and formatting
 
 ### Changed
 
-- `/wiki init` logic refactored into `bin/wiki-init.sh` and `bin/copy-templates.sh` (#20).
-- `CLAUDE.md` and `AGENTS.md` rewritten for plugin context (#13).
+- Release v1.2.0
+- Remove quotes from titles in markdown files for consistency
+- Replace prettier with dprint for token-compact markdown formatting
+- Tighten prettier for token efficiency (proseWrap never, printWidth 10000)
+- Format vault to prettier + markdownlint baseline
+- Exclude node_modules from tracking
+- Add prettier + markdownlint formatting toolchain
+- Demote checks #3–#5 to manual, trim skill descriptions
+
+### Documentation
+
+- Backfill 0.5.1 and 1.1.0 entries
 
 ### Fixed
 
-- `resolve-vault.sh` falls back to `settings.local.json` for out-of-session invocations where `${user_config.*}` is unavailable (#33, #32).
-- Hooks pass `vault_path` as an argument to `resolve-vault.sh` (#29).
+- Quote {{today}} so prettier doesn't split it into { { today } }
+- Handle empty backlinks output before piping to jq
+- Pass vault= after verb, not before
+
+### Testing
+
+- Audit 16 lint checks and add tier-2 fixture vault
+## [1.1.0] - 2026-05-03
+### Added
+
+- E2E harness — local full tier (entrypoint + assertions + Makefile)
+- E2E harness — CI fast tier (Dockerfile + workflow)
+- Emit trail page recording argument order per run
+- Add check #15 — misplaced index entries by type
+- Backlink-aware traversal and density check
+- Add initial lint report for wiki metadata validation
+- Convert 7 skills to Obsidian CLI wrapper
+- Pre-authorize safe auto-fixes for unattended runs
+- Rich capture inputs — image + URL redirect
+- /daily-close as standalone skill
+- /braindump skill — long-form text → atomic-thought split
+- /daily skill + _shared/capture-pipeline.md extraction
+- Title-driven filename slug for /note (closes #61)
+
+### Changed
+
+- Release v1.1.0
+- Ignore .worktrees directory
+- Vault cleanup: slug bug fix, lint rotation, seed onboarding
+- Migrate to unified domain hub architecture (closes #46)
+- Release v1.0.0
+- MCP purge + v1.0.0 CHANGELOG + cli-setup examples (closes #53)
+- Audit hooks, scripts, bin — CLI migration
+
+### Documentation
+
+- Drop Wiki Map.canvas reference from FIRST_RUN
+- Reference docs rewrite — cli-setup.md, drop MCP/REST path
+- Add cli.md — empirical Obsidian CLI contract
+
+### Fixed
+
+- Atomic CLI verbs to stop bullet-loss in /daily (PR1 of #98)
+- Make dead-link check deterministic via lint-scan.sh
+- Register commands directory in manifest
+- Replace whole-file prepend with section-aware splice for index updates

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test e2e e2e-build e2e-clean e2e-preflight
+.PHONY: test e2e e2e-build e2e-clean e2e-preflight changelog
 
 # Deterministic test tier — wrapper smoke + AC1 regression for #98. Both
 # scripts skip with exit 0 when Obsidian is not running, so this target is
@@ -45,3 +45,7 @@ e2e: e2e-preflight e2e-build
 
 e2e-clean:
 	docker image rm claude-obsidian-e2e:latest 2>/dev/null || true
+
+changelog:
+	sed -i '/^## \[Unreleased\]/,/^## \[/{/^## \[Unreleased\]/d;/^## \[/!d}' CHANGELOG.md
+	git cliff --unreleased --prepend CHANGELOG.md

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,52 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+"""
+body = """
+{%- if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{%- else %}\
+## [Unreleased]
+{%- endif %}\
+
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first() }}
+{% for commit in commits %}
+- {{ commit.message | upper_first() }}
+{%- endfor %}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+commit_preprocessors = [
+  { pattern = "\n[\\s\\S]*", replace = "" },
+  { pattern = " *\\(#\\d+\\)", replace = "" },
+  { pattern = "^Initial commit.*", replace = "chore: initial commit" },
+]
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^test", group = "Testing" },
+  { message = "^ci", group = "Infrastructure" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^bump", group = "Changed" },
+  { message = "^chore", group = "Changed" },
+  { message = "^perf", group = "Performance" },
+  { message = ".*", group = "Changed" },
+]
+filter_commits = false
+tag_pattern = "v[0-9]*"
+skip_tags = "v0\\."
+topo_order = false
+sort_commits = "newest"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,32 @@
       "name": "claude-obsidian",
       "version": "0.0.1",
       "devDependencies": {
+        "git-cliff": "^2.13.1",
         "husky": "^9.1",
         "lint-staged": "^15.5"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-escapes": {
@@ -217,6 +238,22 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -251,6 +288,224 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-cliff": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/git-cliff/-/git-cliff-2.13.1.tgz",
+      "integrity": "sha512-2BzXwrom+SMHeNA5Ut+MtzqXejg0wbVwmzj3k7e9w62UQoyCDrM9UIcvtl6hnT3jocEQ1zLRQBaXXx97Gmnk7A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "execa": "^9.6.0"
+      },
+      "bin": {
+        "git-cliff": "lib/cli/cli.js"
+      },
+      "engines": {
+        "node": "^18.19 || >=20.6"
+      },
+      "optionalDependencies": {
+        "git-cliff-darwin-arm64": "2.13.1",
+        "git-cliff-darwin-x64": "2.13.1",
+        "git-cliff-linux-arm64": "2.13.1",
+        "git-cliff-linux-x64": "2.13.1",
+        "git-cliff-windows-arm64": "2.13.1",
+        "git-cliff-windows-x64": "2.13.1"
+      }
+    },
+    "node_modules/git-cliff-darwin-arm64": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/git-cliff-darwin-arm64/-/git-cliff-darwin-arm64-2.13.1.tgz",
+      "integrity": "sha512-3ebPUnUlLmrSZDHknSZQmyZV7DEJVtKse8I25Am0cENET5Py9u9Hg9k8IRXdiDtHtPDs6MYZx7BOi11WtcfqSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/git-cliff-darwin-x64": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/git-cliff-darwin-x64/-/git-cliff-darwin-x64-2.13.1.tgz",
+      "integrity": "sha512-KZfggGAiw1EvZH3BOUclEU4eGCP2+Z+lH/N2Ni3FH9L2M1U7FYJqqaMhqgO8azTj67betvDshH8WBUkIkSsVxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/git-cliff-linux-arm64": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/git-cliff-linux-arm64/-/git-cliff-linux-arm64-2.13.1.tgz",
+      "integrity": "sha512-clNRcNzdvk4GKyTt3ZhhWqcrjVRghcUcGNSV/Y87YJf3Mc/zl9ajUAhnXPOBSX/KWBr2od5SmkCt0qGYagY07g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/git-cliff-linux-x64": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/git-cliff-linux-x64/-/git-cliff-linux-x64-2.13.1.tgz",
+      "integrity": "sha512-gZcIQhIQ1lDUMD8UieUSEZAYoyZN7nPd8O3VQoj1Ddhqll4UAS1Zxms1SU3U8pb0UTdc2m3ia/wtOnyhvbjdjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/git-cliff-windows-arm64": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/git-cliff-windows-arm64/-/git-cliff-windows-arm64-2.13.1.tgz",
+      "integrity": "sha512-+XubuQv68DuDwF0u6Af5d889MEf/RD48VBQS7ZmPi4sUSCXAZqRm1/ApCsStLqxMDCf1+7s05B/kNbm9wjV80A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/git-cliff-windows-x64": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/git-cliff-windows-x64/-/git-cliff-windows-x64-2.13.1.tgz",
+      "integrity": "sha512-Bi8ehp1VMkomY7M/356PgovKQ8CBRiuOOkq+aWC2evQuMFfXWjG0GBlPED9QkZoUJ4iQ5ygB5DYdK3BjhaOyPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/git-cliff/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/git-cliff/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-cliff/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/git-cliff/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-cliff/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-cliff/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-cliff/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -305,6 +560,19 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -313,6 +581,19 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -536,6 +817,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -570,6 +864,22 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -735,6 +1045,19 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -783,6 +1106,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "bin/minify-md -i -r ."
   },
   "devDependencies": {
+    "git-cliff": "^2.13.1",
     "husky": "^9.1",
     "lint-staged": "^15.5"
   },


### PR DESCRIPTION
## Summary

closes #152 

Add automated changelog generation using [git-cliff](https://git-cliff.org), mirroring the whisper-anywhere pattern. All five requirements from the issue are implemented.

## Changes

1. **cliff.toml** — Mirror of `whisper-anywhere/cliff.toml`: Keep a Changelog + SemVer header, conventional commits parsing, section mapping (feat→Added, fix→Fixed, docs→Documentation, test→Testing, ci→Infrastructure, refactor/chore/bump→Changed, perf→Performance, catch-all→Changed), `tag_pattern = "v[0-9]*"`, `skip_tags = "v0\\."`, commit preprocessors, `sort_commits = "newest"`.

2. **package.json** — Added `git-cliff` npm devDependency (`^2.13.1`).

3. **CHANGELOG.md** — Regenerated from git tags via `git cliff`. 13 version sections (Unreleased + v1.1.0 through v1.8.0). v0.x releases are excluded per `skip_tags` config; v1.0.0 commits are subsumed under v1.1.0 (the tag is an ancestor).

4. **Makefile** — Added `changelog` target: removes existing Unreleased section then prepends fresh entries via `git cliff --unreleased --prepend`.

5. **release.yml** — Updated workflow: adds `npm ci` step, updates CHANGELOG.md via `git cliff --tag`, includes CHANGELOG.md in the commit, generates release body via `git cliff --latest --strip header`, and uses `--notes-file` instead of `--generate-notes`.

## Notes

- The `git-cliff` npm package registers `git cliff` as a git subcommand, so `git cliff` works directly (no `npx` prefix needed).
- v0.x releases (v0.2.0–v0.5.1) are excluded per `skip_tags = "v0\\."" config, matching the whisper-anywhere pattern.
- `v1.0.0` is an ancestor of `v1.1.0`, so its commits appear under the v1.1.0 release section rather than as a standalone section.

## Testing

- [x] `make changelog` prepends new unreleased entries to CHANGELOG.md
- [x] `cliff.toml` generates correct sections from conventional commits
- [x] All v1.x releases appear correctly in regenerated CHANGELOG.md (12 v1.x releases)
- [x] Release workflow steps updated (npm ci, CHANGELOG update, commit, release body generation)
- [x] `git cliff --latest --strip header` produces correctly stripped release notes