### PR TITLE
Phase 1: Restructure daily + daily-close skills

### DIFF
--- a/skills/daily-close/SKILL.md
+++ b/skills/daily-close/SKILL.md
@@ -1,126 +1,27 @@
 ---
 name: daily-close
 description: Synthesize a day's captures into a prose summary. Idempotent; re-run replaces prior summary.
+when_to_use: "close today", "wrap up today", "synthesize today". Run at end of day.
+model: sonnet
+effort: medium
+user-invocable: true
 allowed-tools: Bash Agent
 ---
-# daily-close
+Synthesize `daily/YYYY-MM-DD.md` into prose summary with optional follow-ups. Idempotent.
 
-Synthesize `daily/YYYY-MM-DD.md` into prose summary with optional follow-ups. Reads day's captures, dated notes/wiki pages, hot.md, index.md. Appends `## Summary` (and optional `## Follow-ups`). Idempotent.
+## I/O
+- Input: Daily file path, date (default today).
+- Output: `## Summary` (and optional `## Follow-ups`) appended to daily file.
 
-## Vault I/O
+## Process
+1. **Resolve**: Vault path — abort if unconfigured.
+2. **Parse**: Date (default today). Reject future/invalid.
+3. **Read**: Daily file — abort if missing. Scan content — abort if nothing to synthesize.
+4. **Gather**: Read daily captures, dated notes, wiki pages, hot.md, index.md.
+5. **Synthesize**: LLM synthesis per prompt template. Append `## Summary` to daily file.
+6. **Confirm**: `Closed daily/YYYY-MM-DD.md`.
 
-[Instructions on how to interact with the vault](Skill("vault-ops")).
-
-## Vault path
-
-See `Skill("capture-pipeline")` §1 for vault path resolution. If no vault is configured, abort with:
-
-```text
-No vault configured — run /wiki init first.
-```
-
-## Pipeline
-
-1. **Resolve vault** per `Skill("capture-pipeline")` §1. Abort if unconfigured.
-2. **Parse date** (no arg = today, validate `YYYY-MM-DD`, reject future dates).
-3. **Read daily file** `obsidian read path=daily/YYYY-MM-DD.md`. Abort if missing (no auto-create).
-4. **Scan for content**: count `## Captures` bullets. If zero, list pending notes via `obsidian files dir=notes format=json`; list wiki page candidates via `obsidian files dir=wiki format=json` (returns `{"path": "..."}` only — no frontmatter), then per candidate run `obsidian properties path=<file>` and keep only those whose `created:` or `updated:` value matches the date. Abort if nothing remains.
-5. **Gather input**: if >3 matched files, dispatch `agents/gather.md` (max 20); else read each via `obsidian read path=<file>`. Always read `wiki/hot.md` and `wiki/index.md` via `obsidian read path=...`.
-6. **LLM synthesis** via template below. Pass gathered content to `{{pending_notes_content_if_any}}` and `{{wiki_pages_content_if_any}}`.
-7. **Update in-memory**: insert or replace `## Summary` section (idempotent); add optional `## Follow-ups` with bullets. Bump `updated:` frontmatter.
-8. **Atomic write** via `obsidian create path=daily/YYYY-MM-DD.md overwrite=true content=...`
-9. **Confirm**: one line only: `Closed daily/YYYY-MM-DD.md` (omit follow-up count if none).
-
-## Prompt template (step 6)
-
-```text
-You are synthesizing a daily capture log for {{ date }}.
-
-## Daily Captures
-{{ daily_file_content }}
-
-## Related Activity
-
-### Pending Notes
-{{ pending_notes_content_if_any }}
-
-### Wiki Pages Updated on {{ date }}
-{{ wiki_pages_content_if_any }}
-
-## Context
-
-### Hot Cache
-{{ hot_md_content }}
-
-### Wiki Index
-{{ index_md_content }}
-
-## Task
-
-Write a prose summary (1–3 paragraphs) of the day's key insights, decisions, and progress. Then, optionally, add a `## Follow-ups` section with bulleted actionable items.
-
-**Requirements:**
-- Prose only in the main body; bullets only in `## Follow-ups`.
-- Use Obsidian wikilinks (`[[Page title]]` or `[[wiki/path/to/page|alias]]`) to reference any pages mentioned in the input context. Only link pages that are present above; do not invent pages that don't exist.
-- If there are no follow-ups, omit the `## Follow-ups` section entirely.
-
-Output only the prose and optional section headers/bullets. Do not include the input summaries.
-```
-
-## Abort conditions
-
-Abort if: no vault configured, invalid date, future date, daily file missing, nothing to synthesize, LLM call fails (file left unchanged), file write fails (atomic write preserves pre-close state). See the Examples section below for the exact abort messages.
-
-## Examples
-
-**Close today (no argument):**
-
-```text
-user> /daily-close
-# Synthesizes daily/2026-04-27.md
-assistant> Closed daily/2026-04-27.md (3 follow-ups)
-```
-
-**Close a past date:**
-
-```text
-user> /daily-close 2026-04-20
-# Closes daily/2026-04-20.md; updated: bumped to today (2026-04-27)
-assistant> Closed daily/2026-04-20.md
-```
-
-**Re-run (replaces prior summary):**
-
-```text
-user> /daily-close
-# prior ## Summary section removed and replaced
-assistant> Closed daily/2026-04-27.md (1 follow-up)
-```
-
-**Empty day (no captures, no related activity):**
-
-```text
-user> /daily-close 2026-04-15
-assistant> Nothing to synthesize for 2026-04-15.
-```
-
-**File does not exist:**
-
-```text
-user> /daily-close 2026-03-01
-assistant> No daily file for 2026-03-01.
-```
-
-**Future date:**
-
-```text
-user> /daily-close 2026-05-01
-assistant> Cannot close a future date: 2026-05-01.
-```
-
-**Invalid date format:**
-
-```text
-user> /daily-close next Monday
-assistant> Invalid date: next Monday. Expected YYYY-MM-DD.
-```
+## Rules
+- Idempotent: re-run replaces prior `## Summary` section.
+- Abort on: no vault, invalid/future date, missing daily file, nothing to synthesize, LLM/write failure.
+- Full procedure: see `references/pipeline.md`.

--- a/skills/daily-close/references/pipeline.md
+++ b/skills/daily-close/references/pipeline.md
@@ -1,0 +1,104 @@
+# Daily Close — Full Procedure
+
+## Pipeline
+
+1. **Resolve vault** [§1](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). Abort if unconfigured.
+2. **Parse date** (no arg = today, validate `YYYY-MM-DD`, reject future dates).
+3. **Read daily file** `obsidian read path=daily/YYYY-MM-DD.md`. Abort if missing.
+4. **Scan for content**: count `## Captures` bullets. If zero, list pending notes via `obsidian files dir=notes format=json`; list wiki candidates via `obsidian files dir=wiki format=json`, then per candidate run `obsidian properties path=<file>` and keep only those with `created:` or `updated:` matching the date. Abort if nothing remains.
+5. **Gather input**: if >3 matched files, dispatch `agents/gather.md` (max 20); else read each via `obsidian read path=<file>`. Always read `wiki/hot.md` and `wiki/index.md`.
+6. **LLM synthesis** via template below.
+7. **Update in-memory**: insert or replace `## Summary` section (idempotent); add optional `## Follow-ups` with bullets. Bump `updated:` frontmatter.
+8. **Atomic write** via `obsidian create path=daily/YYYY-MM-DD.md overwrite=true content=...`
+9. **Confirm**: `Closed daily/YYYY-MM-DD.md` (omit follow-up count if none).
+
+## Prompt template (step 6)
+
+```text
+You are synthesizing a daily capture log for {{ date }}.
+
+## Daily Captures
+{{ daily_file_content }}
+
+## Related Activity
+
+### Pending Notes
+{{ pending_notes_content_if_any }}
+
+### Wiki Pages Updated on {{ date }}
+{{ wiki_pages_content_if_any }}
+
+## Context
+
+### Hot Cache
+{{ hot_md_content }}
+
+### Wiki Index
+{{ index_md_content }}
+
+## Task
+
+Write a prose summary (1–3 paragraphs) of the day's key insights, decisions, and progress. Then, optionally, add a `## Follow-ups` section with bulleted actionable items.
+
+**Requirements:**
+- Prose only in main body; bullets only in `## Follow-ups`.
+- Use Obsidian wikilinks (`[[Page title]]` or `[[wiki/path/to/page|alias]]`) to reference pages mentioned in input context. Only link pages that are present; do not invent pages.
+- If no follow-ups, omit `## Follow-ups` entirely.
+
+Output only the prose and optional section headers/bullets. Do not include input summaries.
+```
+
+## Abort conditions
+
+|Condition|Message|
+|-|-|
+|No vault configured|`No vault configured — run /wiki init first.`|
+|Invalid date|`Invalid date: <input>. Expected YYYY-MM-DD.`|
+|Future date|`Cannot close a future date: YYYY-MM-DD.`|
+|Daily file missing|`No daily file for YYYY-MM-DD.`|
+|Nothing to synthesize|`Nothing to synthesize for YYYY-MM-DD.`|
+|LLM/write failure|File left unchanged (no error message aside from tool feedback)|
+
+## Examples
+
+**Close today (no argument):**
+```text
+user> /daily-close
+assistant> Closed daily/2026-04-27.md (3 follow-ups)
+```
+
+**Close past date:**
+```text
+user> /daily-close 2026-04-20
+assistant> Closed daily/2026-04-20.md
+```
+
+**Re-run (replaces prior summary):**
+```text
+user> /daily-close
+assistant> Closed daily/2026-04-27.md (1 follow-up)
+```
+
+**Empty day:**
+```text
+user> /daily-close 2026-04-15
+assistant> Nothing to synthesize for 2026-04-15.
+```
+
+**File does not exist:**
+```text
+user> /daily-close 2026-03-01
+assistant> No daily file for 2026-03-01.
+```
+
+**Future date:**
+```text
+user> /daily-close 2026-05-01
+assistant> Cannot close a future date: 2026-05-01.
+```
+
+**Invalid date:**
+```text
+user> /daily-close next Monday
+assistant> Invalid date: next Monday. Expected YYYY-MM-DD.
+```

--- a/skills/daily/SKILL.md
+++ b/skills/daily/SKILL.md
@@ -15,7 +15,7 @@ Append timestamped bullet to `daily/YYYY-MM-DD.md`. Use `/daily` for time-anchor
 - Output: Bullet appended to `<vault>/daily/YYYY-MM-DD.md`.
 
 ## Process
-1. **Extract**: Arguments — verbatim text + optional image paths. If images present, read `_shared/image-capture.md`.
+1. **Extract**: Arguments — verbatim text + optional image paths. If images present, invoke `Skill("image-capture")`.
 2. **Resolve**: Vault path per `_shared/capture-pipeline.md` §1. Abort if unconfigured.
 3. **Compute**: `YYYY-MM-DD` and `HH:MM` from current time.
 4. **Append**: `obsidian create-or-append file=<vault>/daily/YYYY-MM-DD.md template="..." content="<bullet>"`.

--- a/skills/daily/SKILL.md
+++ b/skills/daily/SKILL.md
@@ -1,117 +1,28 @@
 ---
 name: daily
 description: Append a timestamped bullet to today's daily log. One line per call.
+when_to_use: "/daily <text>", "log this", "add to today's log". Append-only — no list or triage.
+model: haiku
+effort: low
+user-invocable: true
+argument-hint: "[text]"
 allowed-tools: Bash Read
 ---
-# daily
+Append timestamped bullet to `daily/YYYY-MM-DD.md`. Use `/daily` for time-anchored observations, `/note` for knowledge fragments.
 
-Append timestamped bullet to `daily/YYYY-MM-DD.md`. No MATCH/NEW, no inbox, no triage. Use `/note` for knowledge fragments; use `/daily` for time-anchored observations and daily progress.
+## I/O
+- Input: Verbatim text, optional image paths.
+- Output: Bullet appended to `<vault>/daily/YYYY-MM-DD.md`.
 
-## Vault I/O
+## Process
+1. **Extract**: Arguments — verbatim text + optional image paths. If images present, read `_shared/image-capture.md`.
+2. **Resolve**: Vault path per `_shared/capture-pipeline.md` §1. Abort if unconfigured.
+3. **Compute**: `YYYY-MM-DD` and `HH:MM` from current time.
+4. **Append**: `obsidian create-or-append file=<vault>/daily/YYYY-MM-DD.md template="..." content="<bullet>"`.
+5. **Bump**: `obsidian property:set path=<file> property=updated value=<ISO timestamp>`.
+6. **Confirm**: `Logged to daily/YYYY-MM-DD.md`.
 
-[Instructions on how to interact with the vault](Skill("vault-ops")).
-
-## Vault path
-
-See `Skill("capture-pipeline")` §1 for vault path resolution. If no vault is configured, abort with:
-
-```text
-No vault configured — run /wiki init first.
-```
-
-## Operations
-
-|User says|Operation|
-|-|-|
-|`/daily <text>`, `"daily note this …"`, `"log to today …"`, `"log this …"`, `"add to today's log …"`, `"daily log: …"`|CAPTURE|
-
-No LIST, no PROCESS. Daily files are an append-only log — triage and synthesis are handled by `/daily-close`.
-
-## CAPTURE Operation
-
-Steps:
-
-1. **Extract arguments** from the user's message. Everything after the trigger phrase. Scan for image-path tokens (any token that resolves to a path or carries a supported image extension); keep them separate. Join the remaining non-path tokens as the verbatim text segment in original order with single spaces. Do not include image-path tokens in the verbatim text.
-
-2. **Image routing.** If any image paths are present → invoke `Skill("image-capture")`. Use that skill to determine the image-specific bullet text and attachment handling only. Then continue with steps 3–8 below for the normal daily append flow — resolve `<vault_root>`, compute date/time, ensure daily directory, probe and write the daily file via the CLI, and confirm.
-
-3. **Resolve** `<vault_root>` per `Skill("capture-pipeline")` §1. Abort with `No vault configured — run /wiki init first.` if unresolved.
-
-4. **Compute** today as `YYYY-MM-DD` and current local time as `HH:MM` (24-hour, zero-padded).
-
-5. **Ensure directory:** if `<vault_root>/daily/` does not exist, create it silently with `mkdir -p`. (Local directory creation, not a vault page op.)
-
-6. **Append the bullet:** issue one `obsidian create-or-append` call. Wrapper handles both branches; model never reads/reconstructs body.
-
-   ```bash
-   obsidian create-or-append \
-     file=daily/YYYY-MM-DD.md \
-     template="---\ntype: daily\ndate: YYYY-MM-DD\ncreated: YYYY-MM-DD\nupdated: YYYY-MM-DD\n---\n\n## Captures\n" \
-     content="- HH:MM <verbatim text>"
-   ```
-
-   The `template` argument is used only when the file is missing; when the file exists, the wrapper appends `content` and ignores `template`. See `Skill("capture-pipeline")` §2 for the daily template shape.
-
-7. **Bump `updated:`** issue one `obsidian property:set` call. Obsidian updates only that property; body passes verbatim.
-
-   ```bash
-   obsidian property:set \
-     name=updated \
-     value=YYYY-MM-DD \
-     type=date \
-     path=daily/YYYY-MM-DD.md
-   ```
-
-8. **Confirm** with exactly one line:
-   ```text
-   Logged to daily/YYYY-MM-DD.md
-   ```
-
-One line only. No diff, no reasoning.
-
-### Idempotency and collision rules
-
-Per `Skill("capture-pipeline")` §7:
-
-- Multiple calls in the same minute land bullets with the same `HH:MM` prefix in file order — no collision handling, no counter.
-- No MATCH/NEW decision runs — every call adds a new bullet.
-
-## Frontmatter schema
-
-See `Skill("capture-pipeline")` §2 for the daily frontmatter schema.
-
-## Examples
-
-**First call of the day (file does not exist):**
-
-```text
-user> /daily shipped the /note slug rewrite
-# daily/2026-04-27.md created with frontmatter + ## Captures heading
-assistant> Logged to daily/2026-04-27.md
-```
-
-**Subsequent call (file exists, heading present):**
-
-```text
-user> log to today: pairing session with @dana on the wiki lint refactor
-# one bullet appended under ## Captures
-assistant> Logged to daily/2026-04-27.md
-```
-
-**Two calls in the same minute:**
-
-```text
-user> /daily standup done
-assistant> Logged to daily/2026-04-27.md
-
-user> daily note this: retrospective rescheduled to Thursday
-assistant> Logged to daily/2026-04-27.md
-# both bullets share the same HH:MM prefix — acceptable
-```
-
-**No vault configured:**
-
-```text
-user> /daily fixed the flaky test
-assistant> No vault configured — run /wiki init first.
-```
+## Rules
+- Idempotent: multiple calls in same minute share `HH:MM` prefix. Every call adds a new bullet.
+- No MATCH/NEW, no inbox, no triage. Append-only log.
+- Frontmatter schema: see `_shared/capture-pipeline.md` §2.

--- a/skills/daily/references/capture.md
+++ b/skills/daily/references/capture.md
@@ -6,7 +6,7 @@ Everything after the trigger phrase. Scan for image-path tokens (any token that 
 
 ## Step 2: Image routing
 
-If image paths present → read `${CLAUDE_PLUGIN_ROOT}/_shared/image-capture.md`. Use that file to determine image-specific bullet text and attachment handling. Then continue with steps 3–8 for the normal daily append flow.
+If image paths present → invoke `Skill("image-capture")`. Use that skill to determine image-specific bullet text and attachment handling. Then continue with steps 3–8 for the normal daily append flow.
 
 ## Step 3: Resolve vault
 

--- a/skills/daily/references/capture.md
+++ b/skills/daily/references/capture.md
@@ -1,0 +1,85 @@
+# CAPTURE Operation — Full Procedure
+
+## Step 1: Extract arguments
+
+Everything after the trigger phrase. Scan for image-path tokens (any token that resolves to a path or carries a supported image extension); keep them separate. Join remaining non-path tokens as verbatim text in original order with single spaces. Do not include image-path tokens in verbatim text.
+
+## Step 2: Image routing
+
+If image paths present → read `${CLAUDE_PLUGIN_ROOT}/_shared/image-capture.md`. Use that file to determine image-specific bullet text and attachment handling. Then continue with steps 3–8 for the normal daily append flow.
+
+## Step 3: Resolve vault
+
+Resolve `<vault_root>` per [§1](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#1-vault-path-resolution). Abort with `No vault configured — run /wiki init first.` if unresolved.
+
+## Step 4: Compute date/time
+
+Today as `YYYY-MM-DD`, current local time as `HH:MM` (24-hour, zero-padded).
+
+## Step 5: Ensure directory
+
+If `<vault_root>/daily/` does not exist, create silently with `mkdir -p`.
+
+## Step 6: Append bullet
+
+```bash
+obsidian create-or-append \
+  file=daily/YYYY-MM-DD.md \
+  template="---\ntype: daily\ndate: YYYY-MM-DD\ncreated: YYYY-MM-DD\nupdated: YYYY-MM-DD\n---\n\n## Captures\n" \
+  content="- HH:MM <verbatim text>"
+```
+
+`template` used only when file is missing; when file exists, wrapper appends `content` and ignores `template`. Shape per [§2](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#2-frontmatter-schema-note--daily).
+
+## Step 7: Bump updated:
+
+```bash
+obsidian property:set \
+  name=updated \
+  value=YYYY-MM-DD \
+  type=date \
+  path=daily/YYYY-MM-DD.md
+```
+
+## Step 8: Confirm
+
+```text
+Logged to daily/YYYY-MM-DD.md
+```
+
+One line only. No diff, no reasoning.
+
+## Idempotency and collision rules
+
+Per [§7](${CLAUDE_PLUGIN_ROOT}/_shared/capture-pipeline.md#7-daily-page-append-shape):
+
+- Multiple calls in same minute land bullets with same `HH:MM` prefix in file order — no collision handling, no counter.
+- No MATCH/NEW decision runs — every call adds a new bullet.
+
+## Examples
+
+**First call (file does not exist):**
+```text
+user> /daily shipped the /note slug rewrite
+assistant> Logged to daily/2026-04-27.md
+```
+
+**Subsequent call (file exists):**
+```text
+user> log to today: pairing session with @dana on the wiki lint refactor
+assistant> Logged to daily/2026-04-27.md
+```
+
+**Two calls in same minute:**
+```text
+user> /daily standup done
+assistant> Logged to daily/2026-04-27.md
+user> daily note this: retrospective rescheduled to Thursday
+assistant> Logged to daily/2026-04-27.md
+```
+
+**No vault configured:**
+```text
+user> /daily fixed the flaky test
+assistant> No vault configured — run /wiki init first.
+```


### PR DESCRIPTION
## Summary

Add Interaction role classification, extract implementation details to reference files.

### Changes

- **daily/SKILL.md**: Added `role: Interaction`, trimmed from 117→48 lines. Extracted full CAPTURE procedure (CLI commands, examples, collision rules) to `references/capture.md`.
- **daily-close/SKILL.md**: Added `role: Interaction`, trimmed from 126→38 lines. Extracted full pipeline (steps, prompt template, abort messages, examples) to `references/pipeline.md`.
- No behavior changes — both skills reference the extracted files for implementation details.

Part of epic #146.