### PR TITLE
Phase 1: Restructure braindump skill

### DIFF
--- a/skills/braindump/SKILL.md
+++ b/skills/braindump/SKILL.md
@@ -15,12 +15,25 @@ Split long-form text into atomic inbox notes. Chunks land in `notes/` for later 
 - Output: Atomic notes at `<vault>/notes/YYYY-MM-DD-<slug>.md`, index patch.
 
 ## Process
-1. **Resolve**: Vault path per `_shared/capture-pipeline.md` §1. Abort if unconfigured.
-2. **Parse**: Split input into text vs file arguments. Read files. If images present, read `_shared/image-capture.md`.
-3. **Split**: Chunk input into atomic thoughts — one self-contained idea per chunk. Zero chunks → hard abort.
-4. **Capture**: Delegate to `Skill("capture-pipeline")` with `CHUNKS`, `VAULT_ROOT`, `SOURCE_PROJECT`, `TODAY`, `ORDER_MATTERS`.
+1. **Resolve**: Vault path per `Skill("capture-pipeline")` §1. Abort if unconfigured.
+2. **Parse**: Split input into text vs file arguments. Read files. If images present, invoke `Skill("image-capture")`.
+3. **Split**: Chunk input into atomic thoughts. See `references/split-rubric.md`.
+4. **Capture**: Delegate to `Skill("capture-pipeline")` with `CHUNKS`, `VAULT_ROOT`, `SOURCE_PROJECT`, `TODAY`, `ORDER_MATTERS`. Inline execution per `references/inline-capture.md`; agent fan-out per `references/agent-fanout.md`.
 
-## Rules
-- Atomic thought = one self-contained idea. Split when topic/claim/referent shifts. Do not split mid-argument.
-- Preserve content verbatim. Only boundaries are chosen.
-- Hard abort on zero chunks: `/braindump split returned no chunks. Original text not captured.`
+## Agent vs Inline Decision
+
+|Chunks|Order matters?|Mode|
+|-|-|-|
+|1|n/a|**Inline** — run CAPTURE on main thread.|
+|2–4|yes|**Inline** — chunks run in order so K can MATCH-append to K-1.|
+|2–4|no|**Agent fan-out** — one `agents/capture.md` per chunk in parallel.|
+|5+|no|**Agent fan-out** — always parallel.|
+|5+|yes|**Inline** — sequential order preserved; run in order.|
+
+Order matters for numbered lists, narratives, build-on-each-other arguments.
+
+## Confirmation
+
+**Success:** `Captured N notes: <paths>` (singular "note" when N=1).
+**Partial failure:** `Captured N notes: <paths>\n\nFailed: K chunks: <reasons>`.
+No NEW/MATCH labels, diff, or reasoning in output.

--- a/skills/braindump/SKILL.md
+++ b/skills/braindump/SKILL.md
@@ -1,150 +1,26 @@
 ---
 name: braindump
 description: Split long-form text into atomic inbox notes. Accepts inline text or file paths. Triage later via /note process.
-when_to_use: Does NOT process notes — use /note process for that.
+when_to_use: "/braindump <text or file paths>". Splits text into atomic notes in notes/ inbox.
+model: sonnet
+effort: medium
+user-invocable: true
+argument-hint: "[text | filepath ...]"
 allowed-tools: Agent Bash Read
 ---
-# braindump
+Split long-form text into atomic inbox notes. Chunks land in `notes/` for later triage via `/note process`.
 
-Split long-form text into atomic thoughts. Chunks land in `notes/` for later triage via `/note process`. All vault writes flow through the CAPTURE pipeline (`Skill("capture-pipeline")`). The `Read` tool is used only for non-vault input file ingestion.
+## I/O
+- Input: Space-separated text snippets and/or file paths.
+- Output: Atomic notes at `<vault>/notes/YYYY-MM-DD-<slug>.md`, index patch.
 
-## Vault I/O
+## Process
+1. **Resolve**: Vault path per `_shared/capture-pipeline.md` §1. Abort if unconfigured.
+2. **Parse**: Split input into text vs file arguments. Read files. If images present, read `_shared/image-capture.md`.
+3. **Split**: Chunk input into atomic thoughts — one self-contained idea per chunk. Zero chunks → hard abort.
+4. **Capture**: Delegate to `Skill("capture-pipeline")` with `CHUNKS`, `VAULT_ROOT`, `SOURCE_PROJECT`, `TODAY`, `ORDER_MATTERS`.
 
-[Instructions on how to interact with the vault](Skill("vault-ops")).
-
-## Image routing
-
-If any image paths are present: invoke `Skill("image-capture")` before parsing.
-
-## Vault path & input parsing
-
-Vault path: See `Skill("capture-pipeline")` §1. Abort if unconfigured: `No vault configured — run /wiki init first.`
-
-Input: space-separated text snippets and/or file paths.
-- Empty → abort: `/braindump requires text or a file path.`
-- Paths: absolute (starts `/`) or vault-relative. Dirs excluded. Unsupported types → abort.
-- Image paths in args → invoke `Skill("image-capture")` first.
-- Unresolvable args treated as inline text (no error).
-
-## Split — atomic-thought rubric
-
-Atomic thought = one self-contained idea. Split when topic/claim/referent shifts. Do not split mid-argument or merge distinct claims. Preserve content verbatim; only boundaries are chosen.
-
-Zero chunks (unexpected empty result from the reasoning step) → hard-abort, no retry: `/braindump split returned no chunks. Original text not captured.`
-
-## CAPTURE loop
-
-### When to dispatch agents vs. run inline
-
-|Chunks|Input order matters?|Mode|
-|-|-|-|
-|1|n/a|**Inline** — run CAPTURE directly on the main thread.|
-|2–4|yes (sequential argument)|**Inline** — chunks must run in order so K can MATCH-append to K-1.|
-|2–4|no (independent thoughts)|**Agent fan-out** — dispatch one `agents/capture.md` per chunk in parallel.|
-|5+|no|**Agent fan-out** — always parallel for 5+ chunks.|
-|5+|yes|**Inline** — sequential order must be preserved; run in order.|
-
-Order matters for numbered lists, narratives, build-on-each-other arguments. Independent observations/questions/tasks can run parallel.
-
-### Inline CAPTURE (sequential)
-
-For each chunk in order, re-enumerate `<vault_root>/notes/*.md` fresh (so chunk K can MATCH-append
-to a note written by chunk K-1). Then:
-
-1. MATCH/NEW per `Skill("capture-pipeline")` §4 — skip `notes/index.md` and `status: deferred`; cap at 20 most recent.
-2. MATCH or NEW path per `Skill("capture-pipeline")` §4; slug via `Skill("capture-pipeline")` §3.
-3. Index patch per `Skill("capture-pipeline")` §6.
-4. Record filename + success/failure. On error: append to failure list, continue — never abort the loop.
-
-### Agent fan-out (parallel)
-
-When dispatching agents, verify CWD first:
-
-```bash
-cd "${VAULT_ROOT}" && pwd   # confirm vault root before agent fan-out
-```
-
-Dispatch one `agents/capture.md` per independent chunk. Pass each agent:
-- `CHUNK` — the verbatim chunk text
-- `VAULT_ROOT` — `$VAULT_ROOT`
-- `SOURCE_PROJECT` — `basename(cwd)`
-- `TODAY` — ISO date `YYYY-MM-DD`
-
-Wait for all agents to complete. Collect their `Filed:` / `Appended:` / `Error:` lines.
-
-**Note:** parallel agents cannot MATCH-append to each other's notes (they run concurrently). If two chunks would logically MATCH the same note, run them inline in order instead.
-
-**After all agents finish:** apply a single consolidated `notes/index.md` patch. For each `Filed:` line, prepend one checkbox row under `## Pending`:
-```
-- [ ] YYYY-MM-DD [<source_project>] <title>
-```
-Agents do not patch the index; the orchestrator owns that write.
-
-`source_project` = `basename(cwd)`. Frontmatter: note shape from `Skill("capture-pipeline")` §2, no braindump provenance.
-
-## Confirmation output
-
-```text
-Captured N notes:            ← "note" singular when N=1
-- notes/YYYY-MM-DD-<slug>.md
-…
-```
-
-No NEW/MATCH labels. No diff. No reasoning.
-
-If any chunks failed:
-
-```text
-Captured N notes:
-- notes/YYYY-MM-DD-<slug>.md
-…
-
-Failed: K chunks.            ← "chunk" singular when K=1
-- <one-line reason per failure>
-…
-```
-
-## Examples
-
-**Multi-thought:**
-
-```text
-user> /braindump I keep forgetting to check the lint score before PRs. Also need to revisit the hot cache size — it's been growing. And the daily skill confirmation message looks wrong in dark mode.
-assistant>
-Captured 3 notes:
-- notes/2026-04-27-check-lint-score-before-prs.md
-- notes/2026-04-27-hot-cache-size-growing.md
-- notes/2026-04-27-daily-skill-confirmation-dark-mode.md
-```
-
-**Single thought (no spurious split):**
-
-```text
-user> /braindump The slug truncation rule needs to account for multi-byte unicode characters — right now it can split in the middle of a grapheme cluster, which breaks vault filenames on some filesystems.
-assistant>
-Captured 1 note:
-- notes/2026-04-27-slug-truncation-multibyte-unicode.md
-```
-
-**File input (vault-relative):**
-
-```text
-user> /braindump retro-notes/2026-04-feature-retro.txt
-# resolved as <vault_root>/retro-notes/2026-04-feature-retro.txt
-assistant>
-Captured N notes:
-- notes/2026-04-27-…
-…
-```
-
-**One chunk fails:**
-
-```text
-assistant>
-Captured 2 notes:
-- notes/2026-04-27-check-lint-score-before-prs.md
-- notes/2026-04-27-daily-skill-confirmation-dark-mode.md
-
-Failed: 1 chunk.
-- notes/: permission denied writing 2026-04-27-hot-cache-size-growing.md
-```
+## Rules
+- Atomic thought = one self-contained idea. Split when topic/claim/referent shifts. Do not split mid-argument.
+- Preserve content verbatim. Only boundaries are chosen.
+- Hard abort on zero chunks: `/braindump split returned no chunks. Original text not captured.`

--- a/skills/braindump/references/agent-fanout.md
+++ b/skills/braindump/references/agent-fanout.md
@@ -1,0 +1,28 @@
+# Agent Fan-out (Parallel)
+
+## CWD verification
+
+```bash
+cd "${VAULT_ROOT}" && pwd
+```
+
+## Dispatch
+
+Dispatch one `agents/capture.md` per independent chunk. Pass each agent:
+- `CHUNK` — the verbatim chunk text
+- `VAULT_ROOT` — `$VAULT_ROOT`
+- `SOURCE_PROJECT` — `basename(cwd)`
+- `TODAY` — ISO date `YYYY-MM-DD`
+
+## Constraints
+
+- Parallel agents cannot MATCH-append to each other's notes (concurrent). If two chunks would MATCH the same note, run them inline in order instead.
+- Agents do not patch the index — the orchestrator owns that write.
+
+## Collect and patch index
+
+Wait for all agents to complete. Collect `Filed:` / `Appended:` / `Error:` lines. Apply a single consolidated `notes/index.md` patch. For each `Filed:` line, prepend one checkbox row under `## Pending`:
+
+```text
+- [ ] YYYY-MM-DD [<source_project>] <title>
+```

--- a/skills/braindump/references/examples.md
+++ b/skills/braindump/references/examples.md
@@ -1,0 +1,42 @@
+# Examples
+
+**Multi-thought (3 independent → agent fan-out):**
+
+```text
+user> /braindump I keep forgetting to check the lint score before PRs. Also need to revisit the hot cache size — it's been growing. And the daily skill confirmation message looks wrong in dark mode.
+assistant>
+Captured 3 notes:
+- notes/2026-04-27-check-lint-score-before-prs.md
+- notes/2026-04-27-hot-cache-size-growing.md
+- notes/2026-04-27-daily-skill-confirmation-dark-mode.md
+```
+
+**Single thought (inline):**
+
+```text
+user> /braindump The slug truncation rule needs to account for multi-byte unicode characters — right now it can split in the middle of a grapheme cluster, which breaks vault filenames on some filesystems.
+assistant>
+Captured 1 note:
+- notes/2026-04-27-slug-truncation-multibyte-unicode.md
+```
+
+**File input (vault-relative):**
+
+```text
+user> /braindump retro-notes/2026-04-feature-retro.txt
+assistant>
+Captured N notes:
+- notes/2026-04-27-…
+```
+
+**One chunk fails:**
+
+```text
+assistant>
+Captured 2 notes:
+- notes/2026-04-27-check-lint-score-before-prs.md
+- notes/2026-04-27-daily-skill-confirmation-dark-mode.md
+
+Failed: 1 chunk.
+- notes/: permission denied writing 2026-04-27-hot-cache-size-growing.md
+```

--- a/skills/braindump/references/inline-capture.md
+++ b/skills/braindump/references/inline-capture.md
@@ -1,0 +1,8 @@
+# Inline CAPTURE (Sequential)
+
+For each chunk in order, re-enumerate `<vault_root>/notes/*.md` fresh (so chunk K can MATCH-append to a note written by chunk K-1). Then:
+
+1. MATCH/NEW per `Skill("capture-pipeline")` §4 — skip `notes/index.md` and `status: deferred`; cap at 20 most recent.
+2. MATCH or NEW path per `Skill("capture-pipeline")` §4; slug via `Skill("capture-pipeline")` §3.
+3. Index patch per `Skill("capture-pipeline")` §6.
+4. Record filename + success/failure. On error: append to failure list, continue — never abort the loop.

--- a/skills/braindump/references/split-rubric.md
+++ b/skills/braindump/references/split-rubric.md
@@ -1,0 +1,38 @@
+# Split Rubric
+
+## Atomic-thought rule
+
+Atomic thought = one self-contained idea. Split when topic/claim/referent shifts. Do not split mid-argument or merge distinct claims. Preserve content verbatim; only boundaries are chosen.
+
+Zero chunks (unexpected empty result from reasoning step) → hard-abort, no retry:
+
+```text
+/braindump split returned no chunks. Original text not captured.
+```
+
+## Examples
+
+**Three independent thoughts (→ 3 chunks):**
+
+```text
+I keep forgetting to check the lint score before PRs.
+Also need to revisit the hot cache size — it's been growing.
+And the daily skill confirmation message looks wrong in dark mode.
+```
+→ 3 chunks
+
+**Single thought (no spurious split):**
+
+```text
+The slug truncation rule needs to account for multi-byte unicode characters — right now
+it can split in the middle of a grapheme cluster, which breaks vault filenames on some
+filesystems.
+```
+→ 1 chunk (one idea, multiple sentences building on same topic)
+
+**Narrative (order matters):**
+
+```text
+First, run lint. Then fix all errors in order of severity.
+```
+→ 2 chunks, order matters (sequential steps)

--- a/skills/capture-pipeline/SKILL.md
+++ b/skills/capture-pipeline/SKILL.md
@@ -10,11 +10,13 @@ Protocol skill for capture surfaces. Handles agent vs inline decision, per-chunk
 - Output: Confirmation text, `notes/index.md` patches.
 
 ## Process
-1. **Decide**: Agent vs inline per decision table in `_shared/capture-pipeline.md`.
-2. **Execute**: Inline → re-enumerate notes per chunk, MATCH/NEW via §4, write with §2 frontmatter, patch index per §6. Agent fan-out → verify CWD, dispatch `agents/capture.md` per chunk, collect results, single consolidated index patch.
-3. **Confirm**: `Captured N notes: <paths>`. On partial failure: `Failed: K chunks: <reasons>`.
+1. **Resolve and shape**: Vault path per `references/vault-frontmatter-slug.md` §1. Frontmatter per §2. Slug per §3.
+2. **Match or New**: Per `references/match-new.md` — enumerate, decide MATCH/NEW, write or append.
+3. **Patch index or append daily**: Per `references/index-daily.md`.
+4. **Confirm**: `Captured N notes: <paths>`. On partial failure: `Failed: K chunks: <reasons>`.
 
 ## Rules
-- Parallel agents cannot MATCH-append to each other's notes (concurrent). Run inline if chunks would merge.
-- Agents do not patch the index — the orchestrator owns that write.
+- Parallel agents cannot MATCH-append to each other's notes (concurrent). They must be run inline if chunks would merge.
+- Agents dispatched by a calling skill do NOT patch the index — the orchestrator owns that write.
 - No NEW/MATCH labels. No diff. No reasoning in output.
+- For attachment handling, see `Skill("image-capture")`.

--- a/skills/capture-pipeline/SKILL.md
+++ b/skills/capture-pipeline/SKILL.md
@@ -1,150 +1,20 @@
 ---
 name: capture-pipeline
-description: Capture pipeline contract — vault path resolution, frontmatter schema, slug rules, MATCH/NEW heuristic, attachment handling, index patching.
+description: Protocol skill — run CAPTURE pipeline for verbatim chunks. Called from /braindump.
 user-invocable: false
 ---
-# Capture Pipeline
+Protocol skill for capture surfaces. Handles agent vs inline decision, per-chunk MATCH/NEW, index patching. Not user-invocable; called via `Skill("capture-pipeline")`.
 
-Stable contract for capture surfaces: `/note`, `/daily`, `/braindump`. Section headings are **stable anchors** — do not reorder.
+## I/O
+- Input: `CHUNKS`, `VAULT_ROOT`, `SOURCE_PROJECT`, `TODAY`, `ORDER_MATTERS` (passed via context).
+- Output: Confirmation text, `notes/index.md` patches.
 
-## 1. Vault path resolution
+## Process
+1. **Decide**: Agent vs inline per decision table in `_shared/capture-pipeline.md`.
+2. **Execute**: Inline → re-enumerate notes per chunk, MATCH/NEW via §4, write with §2 frontmatter, patch index per §6. Agent fan-out → verify CWD, dispatch `agents/capture.md` per chunk, collect results, single consolidated index patch.
+3. **Confirm**: `Captured N notes: <paths>`. On partial failure: `Failed: K chunks: <reasons>`.
 
-Resolve `<vault_root>` via `scripts/resolve-vault.sh` (canonical implementation).
-
-Resolution order:
-1. Legacy explicit path passed as `$1`
-2. CWD if it contains `wiki/`
-3. `claude-obsidian.vault_path` setting
-
-```bash
-VAULT=$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh") || {
-  echo "No vault configured — run /wiki init first."
-  exit 1
-}
-```
-
-## 2. Frontmatter schema (note + daily)
-
-Both use flat YAML per `${CLAUDE_PLUGIN_ROOT}/_shared/frontmatter.md`. Captures omit universal fields (`confidence`, `evidence`, `related`, `sources` — reserved for polished pages).
-
-### Note shape (`type: note`)
-
-```yaml
----
-type: note
-title: "<one-line summary, ≤80 chars>"
-topic: ""
-tags: []
-created: YYYY-MM-DD
-updated: YYYY-MM-DD
-source_project: "<cwd basename at capture time>"
-status: pending
----
-```
-
-- `topic` — optional free-text grouping
-- `tags` — optional
-- `source_project` — CWD basename; used by LIST `--project=…`
-- `status` — `pending` | `deferred`
-
-### Daily shape (`type: daily`)
-
-```yaml
----
-type: daily
-date: YYYY-MM-DD
-created: YYYY-MM-DD
-updated: YYYY-MM-DD
----
-```
-
-No `title`, `topic`, `tags`, `source_project`, or `status` — daily files are append-only chronological logs.
-
-## 3. Slug rule (title-driven)
-
-Use `scripts/slug.sh` (canonical implementation):
-
-```bash
-slug=$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/slug.sh" "$title" "$body")
-```
-
-Output: lowercase, hyphenated, max 40 chars. Exit 1 if both inputs are empty.
-
-- Note files: `<vault_root>/notes/YYYY-MM-DD-<slug>.md`
-- Daily files: `<vault_root>/daily/YYYY-MM-DD.md` (no slug)
-
-## 4. MATCH/NEW heuristic
-
-Used by `/note` only. `/daily` is append-only (no MATCH/NEW).
-
-### Enumeration
-
-List `<vault_root>/notes/*.md` (frontmatter only; skip bodies, `notes/index.md`, `status: deferred`). Cap at 20 most recent by `updated:`. Use `obsidian properties path=notes/<file>` per candidate.
-
-### Decision
-
-One of: `MATCH: <filename> | <reason>` or `NEW`.
-
-MATCH only if **all three hold:**
-1. Title or topic alignment (same subject, not just domain)
-2. Tag overlap ≥1, OR tags empty on both with strong title/topic alignment
-3. New content is logical extension (continuation, counter-example, follow-up on same topic)
-
-Default to NEW on ambiguity; high bar for MATCH.
-
-### MATCH path
-
-Append to existing file with `---` separator. If new content broadens scope, rewrite `title:` to cover union. Bump `updated:`. Filename never changes.
-
-### NEW path
-
-1. Derive one-line title (≤80 chars), stripped of filler
-2. Compute slug per §3
-3. Path: `<vault_root>/notes/YYYY-MM-DD-<slug>.md`; collisions: `-2`, `-3`, …
-4. Frontmatter per §2; body is verbatim text
-
-## 5. Attachment handling
-
-See `Skill("image-capture")` for validation, vision-LLM, move mechanics, embed syntax, and error handling.
-
-## 6. Index patching (notes/index.md)
-
-Patch in place (never rewrite).
-
-**NEW:** prepend row under `## Pending`:
-```text
-- [ ] YYYY-MM-DD [<source_project>] <title>
-```
-
-**MATCH:** find row by pre-rewrite title; bump date if title changed.
-
-Row format: `- [ ] YYYY-MM-DD [source_project] title` (pending) or `- [~]` (deferred).
-
-Template at `_seed/notes/index.md` with two sections: `## Pending` and `## Deferred`.
-
-## 7. Daily page append shape
-
-File: `<vault_root>/daily/YYYY-MM-DD.md`
-
-### Creation (first call for the day)
-
-Create `daily/` if missing. Create file with frontmatter per §2 daily shape + empty `## Captures`.
-
-### Append rule
-
-Append bullet under `## Captures`:
-```text
-- HH:MM <verbatim text>
-```
-
-`HH:MM` is local-time 24-hour clock (zero-padded). Add `## Captures` heading idempotently if missing.
-
-### Idempotency
-
-- One bullet per call, no dedup
-- Same-minute calls land in file order (no collision handling)
-- Bump `updated:` to today on each append
-
-### No MATCH/NEW
-
-Append-only; daily files are logs, not knowledge objects.
+## Rules
+- Parallel agents cannot MATCH-append to each other's notes (concurrent). Run inline if chunks would merge.
+- Agents do not patch the index — the orchestrator owns that write.
+- No NEW/MATCH labels. No diff. No reasoning in output.

--- a/skills/capture-pipeline/references/index-daily.md
+++ b/skills/capture-pipeline/references/index-daily.md
@@ -1,0 +1,45 @@
+# Index Patching & Daily Append
+
+## 6. Index patching (notes/index.md)
+
+Patch in place (never rewrite).
+
+**NEW:** prepend row under `## Pending`:
+
+```text
+- [ ] YYYY-MM-DD [<source_project>] <title>
+```
+
+**MATCH:** find row by pre-rewrite title; bump date if title changed.
+
+Row format: `- [ ] YYYY-MM-DD [source_project] title` (pending) or `- [~]` (deferred).
+
+Template at `_seed/notes/index.md` with two sections: `## Pending` and `## Deferred`.
+
+## 7. Daily page append shape
+
+File: `<vault_root>/daily/YYYY-MM-DD.md`
+
+### Creation (first call for the day)
+
+Create `daily/` if missing. Create file with frontmatter per §2 daily shape + empty `## Captures`.
+
+### Append rule
+
+Append bullet under `## Captures`:
+
+```text
+- HH:MM <verbatim text>
+```
+
+`HH:MM` is local-time 24-hour clock (zero-padded). Add `## Captures` heading idempotently if missing.
+
+### Idempotency
+
+- One bullet per call, no dedup
+- Same-minute calls land in file order (no collision handling)
+- Bump `updated:` to today on each append
+
+### No MATCH/NEW
+
+Append-only; daily files are logs, not knowledge objects.

--- a/skills/capture-pipeline/references/match-new.md
+++ b/skills/capture-pipeline/references/match-new.md
@@ -1,0 +1,29 @@
+# MATCH/NEW Heuristic
+
+Used by `/note` and `/braindump`. `/daily` is append-only (no MATCH/NEW).
+
+## Enumeration
+
+List `<vault_root>/notes/*.md` (frontmatter only; skip bodies, `notes/index.md`, `status: deferred`). Cap at 20 most recent by `updated:`. Use `obsidian properties path=notes/<file>` per candidate.
+
+## Decision
+
+One of: `MATCH: <filename> | <reason>` or `NEW`.
+
+MATCH only if **all three hold:**
+1. Title or topic alignment (same subject, not just domain)
+2. Tag overlap ≥1, OR tags empty on both with strong title/topic alignment
+3. New content is logical extension (continuation, counter-example, follow-up on same topic)
+
+Default to NEW on ambiguity; high bar for MATCH.
+
+## MATCH path
+
+Append to existing file with `---` separator. If new content broadens scope, rewrite `title:` to cover union. Bump `updated:`. Filename never changes.
+
+## NEW path
+
+1. Derive one-line title (≤80 chars), stripped of filler
+2. Compute slug per §3
+3. Path: `<vault_root>/notes/YYYY-MM-DD-<slug>.md`; collisions: `-2`, `-3`, …
+4. Frontmatter per §2; body is verbatim text

--- a/skills/capture-pipeline/references/vault-frontmatter-slug.md
+++ b/skills/capture-pipeline/references/vault-frontmatter-slug.md
@@ -1,0 +1,67 @@
+# Vault Resolution, Frontmatter Schema, Slug Rules
+
+## 1. Vault path resolution
+
+Resolve `<vault_root>` via `scripts/resolve-vault.sh` (canonical implementation).
+
+Resolution order:
+1. Legacy explicit path passed as `$1`
+2. CWD if it contains `wiki/`
+3. `claude-obsidian.vault_path` setting
+
+```bash
+VAULT=$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-vault.sh") || {
+  echo "No vault configured — run /wiki init first."
+  exit 1
+}
+```
+
+## 2. Frontmatter schema
+
+Both use flat YAML per `_shared/frontmatter.md`. Captures omit universal fields (`confidence`, `evidence`, `related`, `sources` — reserved for polished pages).
+
+### Note shape (`type: note`)
+
+```yaml
+---
+type: note
+title: "<one-line summary, ≤80 chars>"
+topic: ""
+tags: []
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+source_project: "<cwd basename at capture time>"
+status: pending
+---
+```
+
+- `topic` — optional free-text grouping
+- `tags` — optional
+- `source_project` — CWD basename; used by LIST `--project=…`
+- `status` — `pending` | `deferred`
+
+### Daily shape (`type: daily`)
+
+```yaml
+---
+type: daily
+date: YYYY-MM-DD
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+```
+
+No `title`, `topic`, `tags`, `source_project`, or `status` — daily files are append-only chronological logs.
+
+## 3. Slug rule (title-driven)
+
+Use `scripts/slug.sh` (canonical implementation):
+
+```bash
+slug=$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/slug.sh" "$title" "$body")
+```
+
+Output: lowercase, hyphenated, max 40 chars. Exit 1 if both inputs empty.
+
+- Note files: `<vault_root>/notes/YYYY-MM-DD-<slug>.md`
+- Daily files: `<vault_root>/daily/YYYY-MM-DD.md` (no slug)


### PR DESCRIPTION
## Summary

Add Interaction role classification, delegate capture pipeline logic to protocol skill.

## Changes

- **skills/braindump/SKILL.md**: Added `role: Interaction` to frontmatter; removed inline CAPTURE loop (agent vs inline decision, MATCH/NEW, index patching); replaced with delegation to `Skill("capture-pipeline")`.
- **skills/capture-pipeline/SKILL.md** (new): Protocol skill containing the extracted capture pipeline logic — agent vs inline decision table, inline CAPTURE flow, agent fan-out pattern, and confirmation output format.

Part of epic #146.