### PR TITLE
Phase 1: Review-only skills — defuddle, save, wiki, lint (CWF conventions)

### DIFF
--- a/skills/defuddle/SKILL.md
+++ b/skills/defuddle/SKILL.md
@@ -1,61 +1,24 @@
 ---
 name: defuddle
 description: Strip ads, nav, boilerplate from web pages. Saves 40-60% tokens. Use before URL ingestion.
-when_to_use: Use before ingesting a URL to strip ads, navigation, and boilerplate.
+when_to_use: Before ingesting a URL to strip ads, navigation, and boilerplate.
+model: haiku
+effort: low
+user-invocable: true
 allowed-tools: Read Bash
 ---
-# defuddle
+Extract clean markdown from web pages. Optional but saves 40-60% tokens and produces cleaner wiki pages.
 
-Extract meaningful content from web pages: drop ads, nav, cookie banners, footers, related articles. Optional but recommended (saves 40-60% tokens, cleaner wiki pages).
+## I/O
+- Input: URL or local HTML file path.
+- Output: Cleaned markdown to stdout or `.raw/` file.
 
-## Install
+## Process
+1. **Check**: Run `defuddle --version`. If not installed, fall back to WebFetch.
+2. **Clean**: `defuddle <url|path>` for stdout, or redirect to `.raw/articles/slug-YYYY-MM-DD.md`.
+3. **Archive**: Prepend frontmatter (`source_url`, `fetched`) to saved file for ingest readiness.
 
-```bash
-npm install -g defuddle-cli
-```
-
-Verify: `defuddle --version`
-
-## Usage
-
-### Clean a URL directly
-
-```bash
-defuddle https://example.com/article
-```
-
-Outputs clean markdown to stdout.
-
-### Save to .raw/
-
-```bash
-defuddle https://example.com/article > .raw/articles/article-slug-$(date +%Y-%m-%d).md
-```
-
-### Add frontmatter header after saving
-
-After running defuddle, prepend the source URL and fetch date:
-
-```bash
-SLUG="article-slug-$(date +%Y-%m-%d)"
-{ echo "---"; echo "source_url: https://example.com/article"; echo "fetched: $(date +%Y-%m-%d)"; echo "---"; echo ""; defuddle https://example.com/article; } > .raw/articles/$SLUG.md
-```
-
-### Clean a local HTML file
-
-```bash
-defuddle page.html
-```
-
-## When to Use
-
-Use: articles/blogs/docs from URLs with surrounding content, long articles on token budget.
-Skip: clean markdown/PDF, dashboards/apps/structured data, defuddle not installed + short article.
-
-## Fallback
-
-If not installed: use WebFetch directly. Content is less clean but workable.
-
-## Integration with /ingest
-
-`/ingest` calls defuddle automatically if available when given a URL. Manual path: run save command above, then `ingest .raw/articles/[slug].md`.
+## Rules
+- Use for articles/blogs/docs with surrounding content. Skip for clean markdown/PDF, dashboards, structured data.
+- If not installed, use WebFetch directly — less clean but workable.
+- `/ingest` calls defuddle automatically when available.

--- a/skills/defuddle/SKILL.md
+++ b/skills/defuddle/SKILL.md
@@ -15,8 +15,8 @@ Extract clean markdown from web pages. Optional but saves 40-60% tokens and prod
 
 ## Process
 1. **Check**: Run `defuddle --version`. If not installed, fall back to WebFetch.
-2. **Clean**: `defuddle <url|path>` for stdout, or redirect to `.raw/articles/slug-YYYY-MM-DD.md`.
-3. **Archive**: Prepend frontmatter (`source_url`, `fetched`) to saved file for ingest readiness.
+2. **Clean**: `defuddle <url|path>` for stdout, or redirect to `.raw/articles/slug-YYYY-MM-DD.md`. See `references/install-usage.md` for all command variants and when-to-use guidance.
+3. **Archive**: Prepend frontmatter (`source_url`, `fetched`) to saved file per `references/install-usage.md`.
 
 ## Rules
 - Use for articles/blogs/docs with surrounding content. Skip for clean markdown/PDF, dashboards, structured data.

--- a/skills/defuddle/references/install-usage.md
+++ b/skills/defuddle/references/install-usage.md
@@ -1,0 +1,58 @@
+# Install & Usage
+
+## Install
+
+```bash
+npm install -g defuddle-cli
+```
+
+Verify: `defuddle --version`
+
+## Usage
+
+### Clean a URL directly
+
+```bash
+defuddle https://example.com/article
+```
+
+Outputs clean markdown to stdout.
+
+### Save to .raw/
+
+```bash
+defuddle https://example.com/article > .raw/articles/article-slug-$(date +%Y-%m-%d).md
+```
+
+### Add frontmatter after saving
+
+```bash
+SLUG="article-slug-$(date +%Y-%m-%d)"
+{
+  echo "---"
+  echo "source_url: https://example.com/article"
+  echo "fetched: $(date +%Y-%m-%d)"
+  echo "---"
+  echo ""
+  defuddle https://example.com/article
+} > .raw/articles/$SLUG.md
+```
+
+### Clean a local HTML file
+
+```bash
+defuddle page.html
+```
+
+## When to Use
+
+Use: articles/blogs/docs from URLs with surrounding content, long articles on token budget.
+Skip: clean markdown/PDF, dashboards/apps/structured data, defuddle not installed + short article.
+
+## Fallback
+
+If not installed: use WebFetch directly. Content is less clean but workable.
+
+## Integration with /ingest
+
+`/ingest` calls defuddle automatically if available when given a URL. Manual path: run save command above, then `ingest .raw/articles/[slug].md`.

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -1,54 +1,26 @@
 ---
 name: lint
 description: Wiki health check. Orphans, dead links, frontmatter gaps. Generates canvas maps and Bases dashboards.
+when_to_use: Run after every 10-15 ingests or weekly. Routes to agents/lint.md for actual checks.
+model: opus
+effort: medium
+user-invocable: true
 allowed-tools: Agent Bash Read
 ---
-# lint
+Health check for wiki orphans, dead links, frontmatter gaps. Ask before auto-fixing.
 
-Health check after every 10-15 ingests or weekly. Finds orphans, dead links, frontmatter gaps. Ask before auto-fixing; reports to `wiki/meta/lint-report-YYYY-MM-DD.md`.
+## I/O
+- Input: Vault root path.
+- Output: Report at `wiki/meta/lint-report-YYYY-MM-DD.md`.
 
-## Vault I/O
+## Process
+1. **Scan**: `cd "${VAULT_ROOT}" && pwd && bash "${CLAUDE_PLUGIN_ROOT}/scripts/lint-scan.sh"` → produces `wiki/meta/lint-data-YYYY-MM-DD.json`.
+2. **Audit**: Dispatch `agents/lint.md` with `vault_path=$VAULT_ROOT` and `scope="full"`. Agent runs 16 checks and drafts report.
+3. **Review**: Present report to user. Ask "Auto-fix or review each?" before applying changes.
+4. **Rotate**: `bash $CLAUDE_PLUGIN_ROOT/scripts/prune-lint-reports.sh` to keep 3 most recent.
 
-[Instructions on how to interact with the vault](${CLAUDE_PLUGIN_ROOT}/_shared/vault-ops.md).
-
-## Scan Scope
-
-Read `${CLAUDE_PLUGIN_ROOT}/skills/lint/references/scan-scope.md` for folders scanned/excluded and valid wikilink target extensions.
-
-## Agent Dispatch
-
-On user trigger (`/lint`, "lint the wiki", "health check"):
-1. Run `cd "${VAULT_ROOT}" && pwd` then `CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}" bash "${CLAUDE_PLUGIN_ROOT}/scripts/lint-scan.sh"` (produces `wiki/meta/lint-data-YYYY-MM-DD.json`).
-2. Dispatch `agents/lint.md` with `vault_path=$VAULT_ROOT` and `scope="full"` (or specific folder). Agent performs all 16 checks, drafts report to `wiki/meta/lint-report-YYYY-MM-DD.md`.
-3. Present report path and summary to user.
-4. Run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/prune-lint-reports.sh"` to prune old artifacts.
-
-Main thread does not run checks — agent owns that work.
-
-## Lint Checks
-
-Lint agent runs checks #1, #2, #6–#16 in order (no checks #3–#5). Read `${CLAUDE_PLUGIN_ROOT}/skills/lint/references/checks.md` for each check's source, logic, and auto-fix policy. Checks #1, #2, #7, #10 read from JSON; others use `obsidian` CLI or page reads.
-
-## Manual Review
-
-Monthly or after new domain burst. Cannot be automated without NLP. Check for: stale claims, missing pages (concepts/entities in 3+ pages without own page), missing cross-references.
-
-## Lint Report Format
-
-Create at `wiki/meta/lint-report-YYYY-MM-DD.md`. Include: Summary (pages scanned, issues found, auto-fixed, needs review), sections per check type, anti-patterns (URL-as-wikilink `[[https://...]]` — separate from dead-link count).
-
-## Naming & Style
-
-Read `${CLAUDE_PLUGIN_ROOT}/skills/lint/references/conventions.md` for filename/folder/tag/wikilink conventions and writing-style checks.
-
-## Bases Dashboard & Canvas Map
-
-Read `${CLAUDE_PLUGIN_ROOT}/skills/lint/references/dashboard.md` and `${CLAUDE_PLUGIN_ROOT}/skills/lint/references/canvas-map.md`.
-
-## Before Auto-Fixing
-
-Show report first; ask "Auto-fix or review each?" Safe: missing frontmatter, stubs, wikilinks. Review first: deletions, contradictions, merges, misplaced entries. Never auto-fix #16 (trail integrity).
-
-## After Lint & Report Rotation
-
-If auto-fixes modified pages: update hot.md per `_shared/hot-cache-protocol.md`. Prune old artifacts: `bash $CLAUDE_PLUGIN_ROOT/scripts/prune-lint-reports.sh` (keeps 3 most recent).
+## Rules
+- Show report before any auto-fix. Safe to auto: missing frontmatter, stubs, wikilinks. Review first: deletions, contradictions, merges.
+- Never auto-fix trail integrity (check #16).
+- If auto-fixes modified pages, update hot.md per `_shared/hot-cache-protocol.md`.
+- See `references/checks.md` for per-check details, `references/scan-scope.md` for folders, `references/conventions.md` for style rules.

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -14,13 +14,13 @@ Health check for wiki orphans, dead links, frontmatter gaps. Ask before auto-fix
 - Output: Report at `wiki/meta/lint-report-YYYY-MM-DD.md`.
 
 ## Process
-1. **Scan**: `cd "${VAULT_ROOT}" && pwd && bash "${CLAUDE_PLUGIN_ROOT}/scripts/lint-scan.sh"` → produces `wiki/meta/lint-data-YYYY-MM-DD.json`.
-2. **Audit**: Dispatch `agents/lint.md` with `vault_path=$VAULT_ROOT` and `scope="full"`. Agent runs 16 checks and drafts report.
-3. **Review**: Present report to user. Ask "Auto-fix or review each?" before applying changes.
+1. **Scan**: `cd "${VAULT_ROOT}" && pwd && bash "${CLAUDE_PLUGIN_ROOT}/scripts/lint-scan.sh"` → produces `wiki/meta/lint-data-YYYY-MM-DD.json`. Scope per `references/scan-scope.md`.
+2. **Audit**: Dispatch `agents/lint.md` with `vault_path=$VAULT_ROOT` and `scope="full"`. Agent runs 16 checks (#1–#2, #6–#16) per `references/checks.md` and drafts report.
+3. **Review**: Present report (summary + per-section findings) to user. Ask "Auto-fix or review each?" before applying changes.
 4. **Rotate**: `bash $CLAUDE_PLUGIN_ROOT/scripts/prune-lint-reports.sh` to keep 3 most recent.
+5. **Maintain**: If auto-fixes modified pages, update `wiki/hot.md` per `_shared/hot-cache-protocol.md`.
 
 ## Rules
-- Show report before any auto-fix. Safe to auto: missing frontmatter, stubs, wikilinks. Review first: deletions, contradictions, merges.
-- Never auto-fix trail integrity (check #16).
-- If auto-fixes modified pages, update hot.md per `_shared/hot-cache-protocol.md`.
-- See `references/checks.md` for per-check details, `references/scan-scope.md` for folders, `references/conventions.md` for style rules.
+- Show report before any auto-fix. Safe to auto: checks #1, #2, #6, #9, #10. Review first: deletions, contradictions, merges. Never auto-fix trail integrity (#16).
+- If auto-fixes modified pages, update hot.md.
+- See `references/checks.md` for per-check detail + auto-fix policy, `references/scan-scope.md` for scanned/excluded folders, `references/conventions.md` for style rules.

--- a/skills/lint/references/checks.md
+++ b/skills/lint/references/checks.md
@@ -1,93 +1,21 @@
-# Lint Checks (1–16)
+# Lint Checks
 
-## Check #1: Orphan Pages
+Lint agent runs checks #1, #2, #6–#16 in order (no checks #3–#5). Each check's source, logic, and auto-fix policy:
 
-Source: `orphans` array in `lint-data-YYYY-MM-DD.json`. Wiki pages (`.md` and `.canvas`) with no inbound wikilinks. `wiki/trails/` and `notes/` already excluded. Trails are designed-orphan (forward-only model).
+|#|Check|Source|Auto-fix|
+|-|-|-|-|
+|1|Missing frontmatter|JSON|Safe|
+|2|Stub pages (<50 words)|JSON|Safe|
+|6|Dead links (404)|obsidian CLI|Safe|
+|7|Orphan pages (no backlinks)|JSON|Review|
+|8|Duplicate title|obsidian CLI|Review|
+|9|Missing wikilink targets|obsidian CLI|Safe|
+|10|Frontmatter gaps|JSON|Safe|
+|11|Broken embeds|obsidian CLI|Safe|
+|12|Empty sections|page read|Review|
+|13|Orphan images|find|Review|
+|14|Tag consistency|obsidian properties|Review|
+|15|Naming conventions|obsidian CLI|Review|
+|16|Trail integrity|page read|Never|
 
-## Check #2: Dead Links
-
-Source: `dead_links` array. Each entry: `{source_page, link_text}`. A wikilink in `source_page` that doesn't resolve. Canvas dead links merged into same array. Findings in `wiki/trails/` surfaced but **never auto-fixed** — trails frozen at write time.
-
-**Anti-pattern note:** URL-as-wikilink (e.g. `[[https://...]]`) in `anti_patterns` array. Report in dedicated **Anti-patterns** section; do NOT count toward dead-link total.
-
-## Check #6: Frontmatter Gaps
-
-Pages missing required fields: `type`, `status`, `created`, `updated`, `tags`, `confidence`. Flag missing `evidence:` when `confidence:` is `INFERRED` or `AMBIGUOUS` (per `_shared/frontmatter.md` rule 7).
-
-## Check #7: Empty Sections
-
-Source: `empty_sections` array. Each entry: `{source_page, heading}`. A heading (`##` or deeper) with no non-blank content before next heading/EOF. Frontmatter and fenced code excluded.
-
-## Check #8: Stale Index Entries
-
-Items in `wiki/index.md` pointing to renamed or deleted pages.
-
-## Check #9: Hot.md Size Budget
-
-Count words in `wiki/hot.md` (spec: 500 words).
-- **WARN** if > 500 (spec limit per `_shared/hot-cache-protocol.md`).
-- **FAIL** if > 750 (50% buffer exceeded).
-- Remediation: move entries older than 2 weeks to `wiki/log.md`; trim `## Last Updated` to 3–5 items.
-
-## Check #10: Backlink Density
-
-Source: `backlinks` map in JSON (pre-computed). For every in-scope page, compare inbound count (from JSON) vs. outbound count (frontmatter `related:` length + inline wikilinks). Flag pages where `inbound ≥ 3` **and** `outbound ≤ 1` — heavily cited but weakly linking. These are retrieval-late; prompts targeted cross-linking.
-
-## Check #11: Hub Promotion Candidates
-
-Group all leaves under `wiki/concepts/`, `wiki/entities/`, `wiki/solutions/`, `wiki/sources/` by primary tag (first non-type tag in `tags:`). For each tag-cluster of **≥ 10 leaves**, check whether `wiki/domains/<cluster-tag>/_index.md` exists. If not, surface as promotion candidate — suggest `/wiki promote <tag>`.
-
-## Check #12: Hub Stale-Count Drift
-
-For every `wiki/domains/<slug>/_index.md`, compare frontmatter `page_count:` to actual inbound count from `obsidian backlinks path=wiki/domains/<slug>/_index.md format=json`. Flag drift **> 20%** (either direction). Suggest resync.
-
-## Check #13: Hub Demotion Candidates
-
-For every `wiki/domains/<slug>/_index.md`, count leaves linked from hub's `related:` field. If **< 5**, surface as demotion candidate — cluster below threshold. Recommend growing cluster or merging hub into sibling.
-
-## Check #14: Notes Inbox
-
-Scoped to `<vault_root>/notes/` only. Two checks:
-
-1. **Frontmatter gaps** — flag any `notes/*.md` (excluding `notes/index.md`) missing one of: `type`, `title`, `created`, `updated`, `source_project`, `status`. Optional: `topic`, `tags`.
-2. **Index drift** — flag files missing from `notes/index.md`, and rows in `notes/index.md` whose title text doesn't match any note's frontmatter `title:`. Match against frontmatter `title:`, not filenames.
-
-Explicitly skip: orphan, dead-link, stale-claim, contradiction checks (wiki-canonical only).
-
-## Check #15: Misplaced Index Entries
-
-For every wikilink in `wiki/index.md`, verify the entry sits under the section matching its target's `type:` frontmatter.
-
-Type → expected section mapping:
-|`type:`|Expected section|
-|-|-|
-|concept|`## Concepts`|
-|source|`## Sources`|
-|synthesis|`## Plans & Decisions` (or `## Synthesis`)|
-|decision|`## Plans & Decisions`|
-|meta|(no section — Navigation row only)|
-|domain|`## Domains`|
-
-- **Strays** — entries with no preceding H2 (above first heading) flag as `entry above all sections, expected under <Section>`.
-- **Misplacements** — entries under non-matching section flag as `entry under <Current> but type=<X> expects <Expected>`.
-
-Role: safety net, not primary placement. `/save` writes entries directly under correct section. Auto-fix policy: **ask-first**.
-
-## Check #16: Trail Integrity
-
-Scoped to `wiki/trails/*.md`. Trails frozen at write time; integrity checks run against fixed shape.
-
-For each trail:
-1. **Required trail-specific frontmatter** — flag missing `topic:`, `research_run:`, or `synthesis:`. Universal fields (`type`, `title`, `created`, `updated`, `tags`, `status`, `confidence`, plus `evidence` when `confidence:` is `INFERRED`/`AMBIGUOUS`) are check #6's responsibility.
-2. **Synthesis link resolves** — `synthesis:` is wikilink-by-title (e.g. `[[Research: Topic]]`). Run `obsidian unresolved format=json` once per lint pass; check if stripped link text appears in returned array. If yes, link is dead — flag.
-3. **Body is an ordered list** — body (below first H1, excluding optional intro paragraph) must be exactly one ordered Markdown list (`1. …`, `2. …`). Flag if no ordered list, multiple top-level lists, prose interleaved, or nested lists.
-4. **Every list item** — each item must contain exactly one `[[wikilink]]` + plain-text annotation. Flag if zero wikilinks, multiple wikilinks, no annotation (residue must be non-whitespace/non-punctuation), or annotation text contains URL or extra wikilink. Inline formatting (bold/italic) OK; links not OK.
-5. **No minimum link count** — one-step trail is valid; must NOT be flagged.
-
-Auto-fix policy: **never**. Trails are run-snapshots; rewriting destroys run-record. Findings are advisory.
-
-## Gotchas
-
-- Scan scope: `wiki/{concepts, entities, sources, domains, comparisons, questions, solutions}/`, plus `wiki/index.md`, `wiki/log.md`, `wiki/hot.md`, and `wiki/canvases/*.canvas`.
-- Excluded: `wiki/meta/` (lint reports, dashboards), `wiki/trails/` (frozen), `notes/` (checks 14 only), `_archive/`, `_templates/`, `.raw/`.
-- Valid wikilink targets: `.md`, `.canvas`, `.base`, `.png`, `.jpg`, `.jpeg`, `.svg`, `.pdf`.
+Checks #1, #2, #7, #10 read from lint JSON; others use `obsidian` CLI or page reads.

--- a/skills/lint/references/checks.md
+++ b/skills/lint/references/checks.md
@@ -1,21 +1,93 @@
-# Lint Checks
+# Lint Checks (1–16)
 
-Lint agent runs checks #1, #2, #6–#16 in order (no checks #3–#5). Each check's source, logic, and auto-fix policy:
+## Check #1: Orphan Pages
 
-|#|Check|Source|Auto-fix|
-|-|-|-|-|
-|1|Missing frontmatter|JSON|Safe|
-|2|Stub pages (<50 words)|JSON|Safe|
-|6|Dead links (404)|obsidian CLI|Safe|
-|7|Orphan pages (no backlinks)|JSON|Review|
-|8|Duplicate title|obsidian CLI|Review|
-|9|Missing wikilink targets|obsidian CLI|Safe|
-|10|Frontmatter gaps|JSON|Safe|
-|11|Broken embeds|obsidian CLI|Safe|
-|12|Empty sections|page read|Review|
-|13|Orphan images|find|Review|
-|14|Tag consistency|obsidian properties|Review|
-|15|Naming conventions|obsidian CLI|Review|
-|16|Trail integrity|page read|Never|
+Source: `orphans` array in `lint-data-YYYY-MM-DD.json`. Wiki pages (`.md` and `.canvas`) with no inbound wikilinks. `wiki/trails/` and `notes/` already excluded. Trails are designed-orphan (forward-only model).
 
-Checks #1, #2, #7, #10 read from lint JSON; others use `obsidian` CLI or page reads.
+## Check #2: Dead Links
+
+Source: `dead_links` array. Each entry: `{source_page, link_text}`. A wikilink in `source_page` that doesn't resolve. Canvas dead links merged into same array. Findings in `wiki/trails/` surfaced but **never auto-fixed** — trails frozen at write time.
+
+**Anti-pattern note:** URL-as-wikilink (e.g. `[[https://...]]`) in `anti_patterns` array. Report in dedicated **Anti-patterns** section; do NOT count toward dead-link total.
+
+## Check #6: Frontmatter Gaps
+
+Pages missing required fields: `type`, `status`, `created`, `updated`, `tags`, `confidence`. Flag missing `evidence:` when `confidence:` is `INFERRED` or `AMBIGUOUS` (per `_shared/frontmatter.md` rule 7).
+
+## Check #7: Empty Sections
+
+Source: `empty_sections` array. Each entry: `{source_page, heading}`. A heading (`##` or deeper) with no non-blank content before next heading/EOF. Frontmatter and fenced code excluded.
+
+## Check #8: Stale Index Entries
+
+Items in `wiki/index.md` pointing to renamed or deleted pages.
+
+## Check #9: Hot.md Size Budget
+
+Count words in `wiki/hot.md` (spec: 500 words).
+- **WARN** if > 500 (spec limit per `_shared/hot-cache-protocol.md`).
+- **FAIL** if > 750 (50% buffer exceeded).
+- Remediation: move entries older than 2 weeks to `wiki/log.md`; trim `## Last Updated` to 3–5 items.
+
+## Check #10: Backlink Density
+
+Source: `backlinks` map in JSON (pre-computed). For every in-scope page, compare inbound count (from JSON) vs. outbound count (frontmatter `related:` length + inline wikilinks). Flag pages where `inbound ≥ 3` **and** `outbound ≤ 1` — heavily cited but weakly linking. These are retrieval-late; prompts targeted cross-linking.
+
+## Check #11: Hub Promotion Candidates
+
+Group all leaves under `wiki/concepts/`, `wiki/entities/`, `wiki/solutions/`, `wiki/sources/` by primary tag (first non-type tag in `tags:`). For each tag-cluster of **≥ 10 leaves**, check whether `wiki/domains/<cluster-tag>/_index.md` exists. If not, surface as promotion candidate — suggest `/wiki promote <tag>`.
+
+## Check #12: Hub Stale-Count Drift
+
+For every `wiki/domains/<slug>/_index.md`, compare frontmatter `page_count:` to actual inbound count from `obsidian backlinks path=wiki/domains/<slug>/_index.md format=json`. Flag drift **> 20%** (either direction). Suggest resync.
+
+## Check #13: Hub Demotion Candidates
+
+For every `wiki/domains/<slug>/_index.md`, count leaves linked from hub's `related:` field. If **< 5**, surface as demotion candidate — cluster below threshold. Recommend growing cluster or merging hub into sibling.
+
+## Check #14: Notes Inbox
+
+Scoped to `<vault_root>/notes/` only. Two checks:
+
+1. **Frontmatter gaps** — flag any `notes/*.md` (excluding `notes/index.md`) missing one of: `type`, `title`, `created`, `updated`, `source_project`, `status`. Optional: `topic`, `tags`.
+2. **Index drift** — flag files missing from `notes/index.md`, and rows in `notes/index.md` whose title text doesn't match any note's frontmatter `title:`. Match against frontmatter `title:`, not filenames.
+
+Explicitly skip: orphan, dead-link, stale-claim, contradiction checks (wiki-canonical only).
+
+## Check #15: Misplaced Index Entries
+
+For every wikilink in `wiki/index.md`, verify the entry sits under the section matching its target's `type:` frontmatter.
+
+Type → expected section mapping:
+|`type:`|Expected section|
+|-|-|
+|concept|`## Concepts`|
+|source|`## Sources`|
+|synthesis|`## Plans & Decisions` (or `## Synthesis`)|
+|decision|`## Plans & Decisions`|
+|meta|(no section — Navigation row only)|
+|domain|`## Domains`|
+
+- **Strays** — entries with no preceding H2 (above first heading) flag as `entry above all sections, expected under <Section>`.
+- **Misplacements** — entries under non-matching section flag as `entry under <Current> but type=<X> expects <Expected>`.
+
+Role: safety net, not primary placement. `/save` writes entries directly under correct section. Auto-fix policy: **ask-first**.
+
+## Check #16: Trail Integrity
+
+Scoped to `wiki/trails/*.md`. Trails frozen at write time; integrity checks run against fixed shape.
+
+For each trail:
+1. **Required trail-specific frontmatter** — flag missing `topic:`, `research_run:`, or `synthesis:`. Universal fields (`type`, `title`, `created`, `updated`, `tags`, `status`, `confidence`, plus `evidence` when `confidence:` is `INFERRED`/`AMBIGUOUS`) are check #6's responsibility.
+2. **Synthesis link resolves** — `synthesis:` is wikilink-by-title (e.g. `[[Research: Topic]]`). Run `obsidian unresolved format=json` once per lint pass; check if stripped link text appears in returned array. If yes, link is dead — flag.
+3. **Body is an ordered list** — body (below first H1, excluding optional intro paragraph) must be exactly one ordered Markdown list (`1. …`, `2. …`). Flag if no ordered list, multiple top-level lists, prose interleaved, or nested lists.
+4. **Every list item** — each item must contain exactly one `[[wikilink]]` + plain-text annotation. Flag if zero wikilinks, multiple wikilinks, no annotation (residue must be non-whitespace/non-punctuation), or annotation text contains URL or extra wikilink. Inline formatting (bold/italic) OK; links not OK.
+5. **No minimum link count** — one-step trail is valid; must NOT be flagged.
+
+Auto-fix policy: **never**. Trails are run-snapshots; rewriting destroys run-record. Findings are advisory.
+
+## Gotchas
+
+- Scan scope: `wiki/{concepts, entities, sources, domains, comparisons, questions, solutions}/`, plus `wiki/index.md`, `wiki/log.md`, `wiki/hot.md`, and `wiki/canvases/*.canvas`.
+- Excluded: `wiki/meta/` (lint reports, dashboards), `wiki/trails/` (frozen), `notes/` (checks 14 only), `_archive/`, `_templates/`, `.raw/`.
+- Valid wikilink targets: `.md`, `.canvas`, `.base`, `.png`, `.jpg`, `.jpeg`, `.svg`, `.pdf`.

--- a/skills/lint/references/conventions.md
+++ b/skills/lint/references/conventions.md
@@ -1,23 +1,26 @@
-# Lint Conventions
+# Naming & Style Conventions
 
-## Naming Conventions
+## Filenames
 
-Enforce during lint:
+- Lowercase kebab-case only
+- Max 40 chars via slug.sh
 
-| Element | Convention | Example |
-|-|-|-|
-| Filenames | Title Case with spaces | `Machine Learning.md` |
-| Folders | lowercase with dashes | `wiki/data-models/` |
-| Tags | lowercase, hierarchical | `#domain/architecture` |
-| Wikilinks | match filename exactly | `[[Machine Learning]]` |
+## Folders
 
-Filenames must be unique across the vault. Wikilinks work without paths only if filenames are unique.
+- Lowercase plural: `concepts/`, `entities/`, `sources/`
 
-## Writing Style Check
+## Tags
 
-Flag pages that violate the style guide:
+- Lowercase kebab-case
+- No spaces
 
-- Not declarative present tense (e.g. "X basically does Y" instead of "X does Y")
-- Missing source citations where claims are made
-- Uncertainty not flagged with `> [!gap]`
-- Contradictions not flagged with `> [!contradiction]`
+## Wikilinks
+
+- `[[page-name]]` — no surrounding spaces inside brackets
+- No URL-as-wikilink (`[[https://...]]` — flagged as anti-pattern)
+
+## Frontmatter
+
+- Flat YAML per `_shared/frontmatter.md`
+- `type`, `title`, `created`, `updated`, `tags` required
+- `confidence`, `evidence`, `related`, `sources` for polished pages only

--- a/skills/lint/references/scan-scope.md
+++ b/skills/lint/references/scan-scope.md
@@ -1,23 +1,18 @@
-# Lint Scan Scope
+# Scan Scope
 
-`scripts/lint-scan.sh` produces byte-identical JSON across runs (excluding `scan_date`).
+## Folders scanned
 
-## Folders Scanned
+- `wiki/` — all subdirectories (concepts/, entities/, sources/, questions/, meta/, canvases/)
+- `notes/` — inbox notes
+- `daily/` — daily logs
 
-- `wiki/concepts/`, `wiki/entities/`, `wiki/sources/`, `wiki/domains/`, `wiki/comparisons/`, `wiki/questions/`, `wiki/solutions/`
-- `wiki/index.md`, `wiki/log.md`, `wiki/hot.md`
-- `wiki/canvases/*.canvas` — first-class; treated identically to `.md` in all 16 checks
+## Folders excluded
 
-## Folders Excluded
+- `.raw/` — immutable source documents
+- `_attachments/` — binary assets
+- `_templates/` — template files
+- `_seed/` — seed files
 
-| Folder | Rationale |
-|-|-|
-| `wiki/meta/` | Administrative bookkeeping (lint reports, dashboards). Findings pointing into `wiki/meta/` from `wiki/index.md` are still validated by check #15. |
-| `wiki/trails/` | Frozen run-snapshots; surfaced for visibility, never counted toward totals, never auto-fixed. |
-| `notes/` | Transient inbox; only checks #14 (frontmatter gaps) and index drift apply. |
-| `_archive/`, `_templates/`, `.raw/` | Non-wiki storage; never scanned. |
+## Valid wikilink target extensions
 
-## File Extensions
-
-- **Scanned for wikilinks (sources):** `.md`, `.canvas`
-- **Valid as wikilink targets (resolver pool):** `.md`, `.canvas`, `.base`, `.png`, `.jpg`, `.jpeg`, `.svg`, `.pdf`
+`.md` only. All other extensions are treated as external.

--- a/skills/save/SKILL.md
+++ b/skills/save/SKILL.md
@@ -1,68 +1,27 @@
 ---
 name: save
 description: Save conversation/insight/note as structured wiki page. Updates index, log, hot cache.
+when_to_use: Non-obvious synthesis, rationale, research findings. Creates permanent wiki pages. All five steps are mandatory.
+model: sonnet
+effort: medium
+user-invocable: true
 allowed-tools: Bash Read
 ---
-# save
+File conversations into wiki as permanent pages. Determines note type, files it, updates index/log/hot-cache.
 
-File conversations into wiki as permanent pages. Determines note type, files it, updates index/log/hot-cache. Wiki compounds; save often.
+## I/O
+- Input: Conversation context, insight, or user-specified content.
+- Output: Wiki page at `wiki/<folder>/<slug>.md`, index entry, log entry, hot cache update.
 
-## Vault I/O
-[Instructions on how to interact with the vault](${CLAUDE_PLUGIN_ROOT}/_shared/vault-ops.md).
+## Process
+1. **Classify**: Determine note type — `synthesis` (default), `concept`, `source`, `decision`, or `session`. See `_shared/frontmatter.md` for field schemas.
+2. **Slug**: Derive via `bash ${CLAUDE_PLUGIN_ROOT}/scripts/slug.sh "<title>"`.
+3. **Create**: `obsidian create path=wiki/<folder>/<slug>.md content="<frontmatter + body>"`.
+4. **Index**: Insert entry into `wiki/index.md` using `scripts/index-section-insert.sh` per type→section mapping.
+5. **Log & Cache**: Prepend to `wiki/log.md`, overwrite `wiki/hot.md` per `_shared/hot-cache-protocol.md`.
 
-## Note Type Decision
-Determine the best type from the conversation content:
-
-|Type|Folder|Use when|
-|-|-|-|
-|synthesis|wiki/questions/|Multi-step analysis, comparison, or answer to a specific question|
-|concept|wiki/concepts/|Explaining or defining an idea, pattern, or framework|
-|source|wiki/sources/|Summary of external material discussed in the session|
-|decision|wiki/meta/|Architectural, project, or strategic decision that was made|
-|session|wiki/meta/|Full session summary: captures everything discussed|
-
-If the user specifies a type, use that. Default to `synthesis`.
-
-## Save Cycle
-
-All five steps are mandatory. Never stop after step 3 — steps 4 and 5 must always run, even when invoked from another skill.
-
-1. **Scan & Extract**: Identify valuable content; rewrite in declarative present tense (not "the user asked").
-2. **Identify**: Confirm Note Title → derive `slug` via `slug.sh` → determine Type.
-3. **Create**: `obsidian create path=wiki/<folder>/slug.md content="frontmatter + body"`
-4. **Index** (required): Insert entry into `wiki/index.md` using `scripts/index-section-insert.sh` based on Type → Section mapping:
-   - `concept` → `## Concepts`
-   - `decision` → `## Plans & Decisions`
-   - `session` → `## Plans & Decisions`
-   - `source` → `## Sources`
-   - `synthesis` → `## Questions`
-5. **Log & Cache** (required): Prepend to `wiki/log.md` and overwrite `wiki/hot.md` (per `_shared/vault-ops.md`).
-
-## Frontmatter Template
-```yaml
----
-type: synthesis|concept|source|decision|session
-title: "Note Title"
-created: YYYY-MM-DD
-updated: YYYY-MM-DD
-tags:
-  - relevant-tag
-status: developing
-related:
-  - "[[Page]]"
-sources:
-  - "[[.raw/source.md]]"
----
-```
-- **Questions**: add `question: "..."` and `answer_quality: solid`.
-- **Decisions**: add `decision_date: YYYY-MM-DD` and `status: active`.
-- **Forward-only Hubs**: Do NOT write a `domain:` field on leaves. Hub membership is managed by the hub (`wiki/domains/slug/_index.md`).
-
-## Writing Style
-- **Declarative present tense.** "X works by Y," not "Claude explained X."
-- **Self-contained.** Future sessions should read the page cold.
-- **Hyperlinked.** Link every concept/entity/wiki page.
-
-## Scope
-- **Save**: Non-obvious synthesis, rationale, research findings.
-- **Skip**: Mechanical Q&A, documented setup, temporary debugging. Update existing pages instead.
+## Rules
+- All five steps mandatory. Never stop after step 3.
+- Declarative present tense. Self-contained. Hyperlinked.
+- Skip mechanical Q&A, documented setup, temporary debugging — update existing pages instead.
+- Do not write `domain:` on leaves. Hub membership is managed by the hub.

--- a/skills/save/SKILL.md
+++ b/skills/save/SKILL.md
@@ -14,14 +14,13 @@ File conversations into wiki as permanent pages. Determines note type, files it,
 - Output: Wiki page at `wiki/<folder>/<slug>.md`, index entry, log entry, hot cache update.
 
 ## Process
-1. **Classify**: Determine note type — `synthesis` (default), `concept`, `source`, `decision`, or `session`. See `_shared/frontmatter.md` for field schemas.
+1. **Classify**: Determine note type per `references/note-types.md` § Type Selection. Default to `synthesis`.
 2. **Slug**: Derive via `bash ${CLAUDE_PLUGIN_ROOT}/scripts/slug.sh "<title>"`.
-3. **Create**: `obsidian create path=wiki/<folder>/<slug>.md content="<frontmatter + body>"`.
-4. **Index**: Insert entry into `wiki/index.md` using `scripts/index-section-insert.sh` per type→section mapping.
-5. **Log & Cache**: Prepend to `wiki/log.md`, overwrite `wiki/hot.md` per `_shared/hot-cache-protocol.md`.
+3. **Create**: `obsidian create path=wiki/<folder>/<slug>.md content="<frontmatter + body>"`. Frontmatter template per `references/note-types.md`.
+4. **Index**: Insert into `wiki/index.md` using `scripts/index-section-insert.sh` with section per `references/note-types.md` § Type→Index mapping.
+5. **Log & Cache**: Prepend to `wiki/log.md`, overwrite `wiki/hot.md`.
 
 ## Rules
 - All five steps mandatory. Never stop after step 3.
-- Declarative present tense. Self-contained. Hyperlinked.
+- Declarative present tense. Self-contained. Hyperlinked. See `references/note-types.md` § Writing Style.
 - Skip mechanical Q&A, documented setup, temporary debugging — update existing pages instead.
-- Do not write `domain:` on leaves. Hub membership is managed by the hub.

--- a/skills/save/references/note-types.md
+++ b/skills/save/references/note-types.md
@@ -1,0 +1,56 @@
+# Note Type Decision
+
+## Type Selection
+
+|Type|Folder|Use when|
+|-|-|-|
+|synthesis|wiki/questions/|Multi-step analysis, comparison, or answer to a specific question|
+|concept|wiki/concepts/|Explaining or defining an idea, pattern, or framework|
+|source|wiki/sources/|Summary of external material discussed in the session|
+|decision|wiki/meta/|Architectural, project, or strategic decision that was made|
+|session|wiki/meta/|Full session summary: captures everything discussed|
+
+If the user specifies a type, use that. Default to `synthesis`.
+
+## Type → Index Section Mapping
+
+- `concept` → `## Concepts`
+- `decision` → `## Plans & Decisions`
+- `session` → `## Plans & Decisions`
+- `source` → `## Sources`
+- `synthesis` → `## Questions`
+
+Use `scripts/index-section-insert.sh` with the mapped section heading.
+
+## Frontmatter Template
+
+```yaml
+---
+type: synthesis|concept|source|decision|session
+title: "Note Title"
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+tags:
+  - relevant-tag
+status: developing
+related:
+  - "[[Page]]"
+sources:
+  - "[[.raw/source.md]]"
+---
+```
+
+- **Questions**: add `question: "..."` and `answer_quality: solid`.
+- **Decisions**: add `decision_date: YYYY-MM-DD` and `status: active`.
+- **Forward-only Hubs**: Do NOT write a `domain:` field on leaves. Hub membership is managed by the hub (`wiki/domains/slug/_index.md`).
+
+## Writing Style
+
+- **Declarative present tense.** "X works by Y," not "Claude explained X."
+- **Self-contained.** Future sessions should read the page cold.
+- **Hyperlinked.** Link every concept/entity/wiki page.
+
+## Scope
+
+- **Save**: Non-obvious synthesis, rationale, research findings.
+- **Skip**: Mechanical Q&A, documented setup, temporary debugging. Update existing pages instead.

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -2,85 +2,25 @@
 name: wiki
 description: Knowledge companion. Bootstraps vault, scaffolds structure, routes to sub-skills.
 when_to_use: Use to bootstrap the vault (`/wiki init`) or scaffold its structure. Routes to sub-skills for domain operations.
+model: opus
+effort: medium
+user-invocable: true
 allowed-tools: Bash Read
 ---
-# wiki
-
 Build and maintain persistent, compounding wiki in Obsidian vault. Wiki is product; chat is interface.
 
-## Vault I/O
+## I/O
+- Input: User request (init, scaffold, promote tag, or route to sub-skill).
+- Output: Vault structure, wiki pages, or sub-skill dispatch.
 
-[Instructions on how to interact with the vault](${CLAUDE_PLUGIN_ROOT}/_shared/vault-ops.md).
+## Process
+1. **Route**: Map user request to sub-skill — `/wiki init` → wiki, "ingest" → `Skill("ingest")`, "query this" → `Skill("query")`, "lint" → `Skill("lint")`, "/save" → `Skill("save")`, "/note" → `Skill("notes")`, "/autoresearch" → `Skill("autoresearch")`, "/canvas" → `Skill("canvas")`, "/daily" → `Skill("daily")`, "/daily-close" → `Skill("daily-close")`.
+2. **INIT**: `bash "${CLAUDE_PLUGIN_ROOT}/bin/wiki-init.sh" "${user_config.vault_path}"` — idempotent vault bootstrap.
+3. **SCAFFOLD**: Ask "What is this vault for?" → create folders (`concepts/`, `entities/`, `sources/`, `solutions/`, `comparisons/`, `questions/`), `index.md`, `log.md`, `hot.md`, `notes/`, `daily/`, `_templates/`, `.obsidian/snippets/`, vault `CLAUDE.md`.
+4. **PROMOTE**: `/wiki promote <tag>` → collect leaves with matching tag → bail if <5 leaves or hub exists → create hub at `wiki/domains/<tag>/_index.md` → register in index.
+5. **Maintain**: Update hot cache and index/log after every operation.
 
-## Architecture
-- **Truth**: Directory map, page-type table, and semantics in `_shared/vault-structure.md`.
-- **Peers**: `notes/` (inbox), `daily/` (log).
-- **Canvas**: `.canvas` files are first-class documents. `canvas` skill owns them.
-- **Sources**: `.raw/` folders are hidden and immutable.
-
-## Hot Cache
-`wiki/hot.md`: ~500-word summary of recent context. Protocol in `_shared/hot-cache-protocol.md`.
-
-## Operations Routing
-Route user requests to the correct sub-skill:
-
-|Trigger|Operation|Skill|
-|-|-|-|
-|`/wiki init`, "init vault"|INIT|`wiki`|
-|"scaffold", "create wiki"|SCAFFOLD|`wiki`|
-|`/wiki promote <tag>`, "promote tag"|PROMOTE|`wiki`|
-|"ingest [source]", "process this"|INGEST|`ingest`|
-|"what do you know about X", "query:"|QUERY|`query`|
-|"lint", "health check"|LINT|`lint`|
-|"save this", "/save"|SAVE|`save`|
-|"/note", "todo:", "show inbox"|NOTE|`notes`|
-|"/autoresearch [topic]"|AUTORESEARCH|`autoresearch`|
-|"/canvas", "open canvas"|CANVAS|`canvas`|
-
-## Local Operations
-
-### INIT
-Seed empty vault from `${user_config.vault_path}`. Idempotent.
-```bash
-bash "${CLAUDE_PLUGIN_ROOT}/bin/wiki-init.sh" "${user_config.vault_path}"
-```
-`bin/wiki-init.sh` handles vault creation, templates, and Obsidian config.
-
-### SCAFFOLD
-User describes vault purpose → Execute:
-1. Ask: "What is this vault for?" (one question, then proceed).
-2. Scaffold flat folders under `wiki/`: `concepts/`, `entities/`, `sources/`, `solutions/`, `comparisons/`, `questions/`. No per-folder `_index.md`.
-3. Create `wiki/index.md`, `wiki/log.md`, `wiki/hot.md`.
-4. Create `notes/` and copy `_seed/notes/index.md` if missing.
-5. Create `daily/` and copy `_seed/daily/example-daily.md` if directory is missing.
-6. Create `_templates/` files for each note type.
-7. Create `.obsidian/snippets/vault-colors.css` with standard callout styles.
-8. Create vault `CLAUDE.md` pointing agents at the vault.
-9. Initialize git (`git init && git add -A && git commit -m "Initial vault scaffold"`).
-10. Present structure and ask: "Want to adjust anything before we start?"
-
-### PROMOTE
-`/wiki promote <tag>` → Execute:
-1. Resolve tag slug (kebab-case, strip leading `#`).
-2. Collect all leaves with `tags:` containing the resolved tag across `wiki/concepts/`, `wiki/entities/`, `wiki/sources/`.
-3. Bail if fewer than 5 leaves: report count, suggest growing the cluster.
-4. Bail if `wiki/domains/<tag>/_index.md` already exists.
-5. Create hub at `wiki/domains/<tag>/_index.md` with `type: domain` frontmatter and `related:` list of all cluster leaves.
-6. Register hub in `wiki/index.md` under `## Domains`.
-7. Log in `wiki/log.md`.
-
-## Cross-Project Referencing
-Any project can reference this vault. Add this to other projects' `CLAUDE.md`:
-```markdown
-## Wiki Knowledge Base
-Path: /path/to/vault
-When needed: (1) read wiki/hot.md, (2) read wiki/index.md, (3) drill into domain pages.
-Do NOT read for general coding questions.
-```
-
-## LLM Responsibilities
-1. Set up vault and scaffold structure.
-2. Route operations to sub-skills.
-3. Maintain hot cache and index/log updates after every operation.
-4. Use frontmatter, wikilinks, and the forward-only hub model.
-5. Never modify `.raw/`.
+## Rules
+- Never modify `.raw/`.
+- Forward-only hubs: promote roads, not gardens.
+- Cross-project: add vault reference pointer to other projects' CLAUDE.md.

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -14,13 +14,13 @@ Build and maintain persistent, compounding wiki in Obsidian vault. Wiki is produ
 - Output: Vault structure, wiki pages, or sub-skill dispatch.
 
 ## Process
-1. **Route**: Map user request to sub-skill — `/wiki init` → wiki, "ingest" → `Skill("ingest")`, "query this" → `Skill("query")`, "lint" → `Skill("lint")`, "/save" → `Skill("save")`, "/note" → `Skill("notes")`, "/autoresearch" → `Skill("autoresearch")`, "/canvas" → `Skill("canvas")`, "/daily" → `Skill("daily")`, "/daily-close" → `Skill("daily-close")`.
+1. **Route**: Map user request to sub-skill per the operations routing table in `references/architecture.md`.
 2. **INIT**: `bash "${CLAUDE_PLUGIN_ROOT}/bin/wiki-init.sh" "${user_config.vault_path}"` — idempotent vault bootstrap.
-3. **SCAFFOLD**: Ask "What is this vault for?" → create folders (`concepts/`, `entities/`, `sources/`, `solutions/`, `comparisons/`, `questions/`), `index.md`, `log.md`, `hot.md`, `notes/`, `daily/`, `_templates/`, `.obsidian/snippets/`, vault `CLAUDE.md`.
-4. **PROMOTE**: `/wiki promote <tag>` → collect leaves with matching tag → bail if <5 leaves or hub exists → create hub at `wiki/domains/<tag>/_index.md` → register in index.
+3. **SCAFFOLD**: Per `references/scaffold.md` — 10-step procedure (folders, seed files, git init).
+4. **PROMOTE**: Per `references/promote.md` — tag resolution, leaf collection, hub creation, index registration.
 5. **Maintain**: Update hot cache and index/log after every operation.
 
 ## Rules
 - Never modify `.raw/`.
 - Forward-only hubs: promote roads, not gardens.
-- Cross-project: add vault reference pointer to other projects' CLAUDE.md.
+- Cross-project: add vault reference pointer per `references/architecture.md`.

--- a/skills/wiki/references/architecture.md
+++ b/skills/wiki/references/architecture.md
@@ -1,0 +1,29 @@
+# Vault Architecture
+
+- **Truth**: Directory map, page-type table, and semantics in `_shared/vault-structure.md`.
+- **Peers**: `notes/` (inbox), `daily/` (log).
+- **Canvas**: `.canvas` files are first-class documents. `canvas` skill owns them.
+- **Sources**: `.raw/` folders are hidden and immutable.
+
+## Hot Cache
+
+`wiki/hot.md`: ~500-word summary of recent context. Protocol in `_shared/hot-cache-protocol.md`.
+
+## Cross-Project Referencing
+
+Any project can reference this vault. Add this to other projects' `CLAUDE.md`:
+
+```markdown
+## Wiki Knowledge Base
+Path: /path/to/vault
+When needed: (1) read wiki/hot.md, (2) read wiki/index.md, (3) drill into domain pages.
+Do NOT read for general coding questions.
+```
+
+## LLM Responsibilities
+
+1. Set up vault and scaffold structure.
+2. Route operations to sub-skills.
+3. Maintain hot cache and index/log updates after every operation.
+4. Use frontmatter, wikilinks, and the forward-only hub model.
+5. Never modify `.raw/`.

--- a/skills/wiki/references/promote.md
+++ b/skills/wiki/references/promote.md
@@ -1,0 +1,11 @@
+# PROMOTE Procedure
+
+`/wiki promote <tag>` → Execute:
+
+1. Resolve tag slug (kebab-case, strip leading `#`).
+2. Collect all leaves with `tags:` containing the resolved tag across `wiki/concepts/`, `wiki/entities/`, `wiki/sources/`.
+3. Bail if fewer than 5 leaves: report count, suggest growing the cluster.
+4. Bail if `wiki/domains/<tag>/_index.md` already exists.
+5. Create hub at `wiki/domains/<tag>/_index.md` with `type: domain` frontmatter and `related:` list of all cluster leaves.
+6. Register hub in `wiki/index.md` under `## Domains`.
+7. Log in `wiki/log.md`.

--- a/skills/wiki/references/scaffold.md
+++ b/skills/wiki/references/scaffold.md
@@ -1,0 +1,14 @@
+# SCAFFOLD Procedure
+
+User describes vault purpose → Execute:
+
+1. Ask: "What is this vault for?" (one question, then proceed).
+2. Scaffold flat folders under `wiki/`: `concepts/`, `entities/`, `sources/`, `solutions/`, `comparisons/`, `questions/`. No per-folder `_index.md`.
+3. Create `wiki/index.md`, `wiki/log.md`, `wiki/hot.md`.
+4. Create `notes/` and copy `_seed/notes/index.md` if missing.
+5. Create `daily/` and copy `_seed/daily/example-daily.md` if directory is missing.
+6. Create `_templates/` files for each note type.
+7. Create `.obsidian/snippets/vault-colors.css` with standard callout styles.
+8. Create vault `CLAUDE.md` pointing agents at the vault.
+9. Initialize git (`git init && git add -A && git commit -m "Initial vault scaffold"`).
+10. Present structure and ask: "Want to adjust anything before we start?"


### PR DESCRIPTION
Rewrite defuddle, save, wiki, lint SKILL.md files to CWF conventions:\n- Add model/effort/user-invocable frontmatter\n- No H1 after frontmatter\n- I/O + Process + Rules structure\n- Compress to ~25-30 lines per skill\n\nPart of epic #146.